### PR TITLE
Add environment template and setup documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# API configuration
+GDELT_API_URL=https://api.gdeltproject.org/api/v2/doc/doc
+APCA_API_KEY_ID=your_alpaca_key
+APCA_API_SECRET_KEY=your_alpaca_secret
+APCA_BASE_URL=https://paper-api.alpaca.markets
+
+# Data directories
+RAW_DATA_DIR=./data/raw
+INTERIM_DATA_DIR=./data/interim
+PROCESSED_DATA_DIR=./data/processed
+MODELING_DIR=./src/sentimental_cap_predictor/modeling
+
+# Model hyperparameters
+LEARNING_RATE=0.001
+LNN_UNITS=64
+DROPOUT_RATE=0.2
+WINDOW_SIZE=10
+BATCH_SIZE=32
+EPOCHS=50
+TRAIN_RATIO=0.8
+SARIMA_ORDER=1,1,1
+SARIMA_SEASONAL_ORDER=1,1,1,7
+SEASONAL_ORDER=1,1,1,12
+PREDICTION_DAYS=14
+TRAIN_SIZE_RATIO=0.8
+
+# Data path and logging
+DATA_PATH=./data/your_data.csv
+LOG_LEVEL=INFO
+
+# Ticker lists (comma-separated)
+TICKER_LIST_TECH=
+TICKER_LIST_ENERGY=
+TICKER_LIST_HEALTH=
+TICKER_LIST_AUTO=
+TICKER_LIST_FINANCIAL=
+TICKER_LIST_MISC=

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# CAP Predictor
+
+## Project Goals
+- Aggregate market and news data for selected tickers
+- Derive sentiment-driven features
+- Train time-series models to forecast stock movements
+- Provide utilities for visualization and trading experiments
+
+## Architecture
+```mermaid
+flowchart TD
+    A[Data Collection\n(datasets)] --> B[Preprocessing]
+    B --> C[Feature Engineering]
+    C --> D[Model Training]
+    D --> E[Visualization & Trading]
+```
+
+## Workflow
+1. **Create environment file**
+   ```bash
+   cp .env.example .env
+   ```
+   Fill in API keys and adjust paths or hyperparameters as needed.
+2. **Install dependencies**
+   ```bash
+   pip install -e .[dev]
+   ```
+3. **Collect data**
+   ```bash
+   python -m sentimental_cap_predictor.dataset TICKER --period 1Y
+   ```
+4. **Generate plots**
+   ```bash
+   python -m sentimental_cap_predictor.plots TICKER
+   ```
+5. **Run sentiment analysis model**
+   ```bash
+   python -m sentimental_cap_predictor.modeling.sentiment_analysis <NEWS_PATH>
+   ```
+
+## Typer CLI Usage
+Each module exposes a Typer application:
+- `sentimental_cap_predictor.dataset` – download price and news data
+- `sentimental_cap_predictor.plots` – visualize processed data
+- `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
+
+Run `--help` with any module for detailed options.


### PR DESCRIPTION
## Summary
- Add `.env.example` with API keys, directories, and model hyperparameters
- Document setup, Typer CLI usage, and project goals in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e41c064d0832bbe50bd0c40e35003