### PR TITLE
Fix README mermaid diagram syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Architecture
 ```mermaid
 flowchart TD
-    A[Data Collection\n(datasets)] --> B[Preprocessing]
+    A[Data Collection<br/>(datasets)] --> B[Preprocessing]
     B --> C[Feature Engineering]
     C --> D[Model Training]
     D --> E[Visualization & Trading]


### PR DESCRIPTION
## Summary
- correct mermaid flowchart syntax in README to render architecture diagram properly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e342a8fb4832ba3226d82831d431c