### PR TITLE
Expose optimizer as module command and document CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,17 @@
+
+# Command Line Interface
+
+## Strategy Optimizer
+
+Run the moving-average strategy optimizer using Typer:
+
+```bash
+python -m sentimental_cap_predictor.trader_utils.strategy_optimizer optimize data/processed/NVDA_prices.csv --iterations 250 --seed 42
+```
+
+The CSV must contain two columns:
+
+- `date` – trading date in YYYY-MM-DD format
+- `close` – closing price for the instrument
+
+Example above runs optimizer on an NVDA CSV.

--- a/src/sentimental_cap_predictor/trader_utils/__init__.py
+++ b/src/sentimental_cap_predictor/trader_utils/__init__.py
@@ -1,0 +1,3 @@
+"""Trading utility modules."""
+
+__all__ = []

--- a/src/sentimental_cap_predictor/trader_utils/strategy_optimizer.py
+++ b/src/sentimental_cap_predictor/trader_utils/strategy_optimizer.py
@@ -17,7 +17,13 @@ import typer
 from loguru import logger
 
 
-app = typer.Typer()
+app = typer.Typer(help="Utilities for strategy optimization")
+
+
+@app.callback()
+def main() -> None:
+    """Entry point for strategy optimizer commands."""
+    return None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- enable `strategy_optimizer` Typer app as module subcommand
- document CLI usage and CSV schema
- ensure `trader_utils` package is properly initialized

## Testing
- `PYTHONPATH=src python -m sentimental_cap_predictor.trader_utils.strategy_optimizer optimize data/processed/NVDA_prices.csv --iterations 250 --seed 42`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e917cc3a8832ba947e04cfa377780