### PR TITLE
Add price ingestion CLI and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ data/
 models/
 *processed_dir_path/
 .env
+# Allow package data module
+!src/sentimental_cap_predictor/data/
+!src/sentimental_cap_predictor/data/**

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,3 +15,15 @@ The CSV must contain two columns:
 - `close` – closing price for the instrument
 
 Example above runs optimizer on an NVDA CSV.
+
+## Data Ingestion
+
+Fetch price history and create optimizer-ready CSV:
+
+```bash
+python -m sentimental_cap_predictor.data.ingest NVDA --period 1Y --interval 1d
+```
+
+This saves:
+- `data/raw/NVDA_prices.parquet` with columns `date, open, high, low, close, adj_close, volume`
+- `data/processed/NVDA_prices.csv` containing only `date` and `close`

--- a/src/sentimental_cap_predictor/data/__init__.py
+++ b/src/sentimental_cap_predictor/data/__init__.py
@@ -1,0 +1,3 @@
+"""Data ingestion utilities."""
+
+__all__ = ["ingest"]

--- a/src/sentimental_cap_predictor/data/ingest.py
+++ b/src/sentimental_cap_predictor/data/ingest.py
@@ -1,0 +1,104 @@
+"""Price data ingestion and normalization utilities."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import typer
+import yfinance as yf
+from loguru import logger
+
+EXPECTED_COLUMNS = [
+    "date",
+    "open",
+    "high",
+    "low",
+    "close",
+    "adj_close",
+    "volume",
+]
+
+
+def fetch_prices(ticker: str, period: str = "5y", interval: str = "1d") -> pd.DataFrame:
+    """Fetch price data for *ticker* using yfinance.
+
+    The returned dataframe has lower-case columns and UTC-normalized ``date``.
+    Retries up to three times with exponential backoff if no data is returned.
+    """
+
+    last_error: Optional[Exception] = None
+    for attempt in range(3):
+        try:
+            logger.debug("Downloading prices for %s (attempt %d)", ticker, attempt + 1)
+            df = yf.download(
+                ticker,
+                period=period,
+                interval=interval,
+                progress=False,
+                auto_adjust=False,
+            )
+            if not df.empty:
+                break
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+        time.sleep(2**attempt)
+    else:
+        raise ValueError(f"No data returned for ticker {ticker}") from last_error
+
+    df = df.reset_index().rename(columns=str.lower)
+    if "adj close" in df.columns:
+        df = df.rename(columns={"adj close": "adj_close"})
+    df["date"] = pd.to_datetime(df["date"], utc=True)
+    df = df.drop_duplicates(subset="date").sort_values("date")
+    df = df[EXPECTED_COLUMNS]
+    df = df.astype(
+        {
+            "open": "float64",
+            "high": "float64",
+            "low": "float64",
+            "close": "float64",
+            "adj_close": "float64",
+            "volume": "int64",
+        }
+    )
+    return df
+
+
+def save_prices(df: pd.DataFrame, ticker: str) -> Path:
+    """Save raw prices to ``data/raw/{ticker}_prices.parquet``."""
+
+    raw_dir = Path("data/raw")
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    path = raw_dir / f"{ticker}_prices.parquet"
+    df.to_parquet(path, index=False)
+    return path
+
+
+def prices_to_csv_for_optimizer(df: pd.DataFrame, ticker: str) -> Path:
+    """Write close prices to ``data/processed/{ticker}_prices.csv``."""
+
+    proc_dir = Path("data/processed")
+    proc_dir.mkdir(parents=True, exist_ok=True)
+    path = proc_dir / f"{ticker}_prices.csv"
+    df[["date", "close"]].to_csv(path, index=False)
+    return path
+
+
+app = typer.Typer(help="Download and prepare price data")
+
+
+@app.command()
+def main(ticker: str, period: str = "5y", interval: str = "1d") -> None:
+    """Fetch prices and materialize parquet/CSV files."""
+
+    df = fetch_prices(ticker, period=period, interval=interval)
+    save_path = save_prices(df, ticker)
+    csv_path = prices_to_csv_for_optimizer(df, ticker)
+    typer.echo(f"Saved parquet to {save_path} and csv to {csv_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    app()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import pytest
+import yfinance as yf
+
+from sentimental_cap_predictor.data import ingest
+
+
+def _sample_download(*args, **kwargs):
+    return pd.DataFrame(
+        {
+            "Date": pd.date_range("2024-01-01", periods=2, tz="US/Eastern"),
+            "Open": [1.0, 2.0],
+            "High": [1.0, 2.0],
+            "Low": [1.0, 2.0],
+            "Close": [1.0, 2.0],
+            "Adj Close": [1.0, 2.0],
+            "Volume": [100, 200],
+        }
+    )
+
+
+def test_fetch_prices_schema(monkeypatch):
+    monkeypatch.setattr(yf, "download", _sample_download)
+    df = ingest.fetch_prices("NVDA")
+    assert list(df.columns) == ingest.EXPECTED_COLUMNS
+    assert str(df["date"].dt.tz) == "UTC"
+    assert df["volume"].dtype == "int64"
+
+
+def test_fetch_prices_empty(monkeypatch):
+    def _empty_download(*args, **kwargs):  # noqa: ANN001
+        return pd.DataFrame()
+
+    monkeypatch.setattr(yf, "download", _empty_download)
+    with pytest.raises(ValueError):
+        ingest.fetch_prices("BAD")
+
+
+def test_save_and_csv(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(yf, "download", _sample_download)
+    df = ingest.fetch_prices("NVDA")
+    raw_path = ingest.save_prices(df, "NVDA")
+    csv_path = ingest.prices_to_csv_for_optimizer(df, "NVDA")
+    assert raw_path.exists()
+    out_df = pd.read_csv(csv_path)
+    assert list(out_df.columns) == ["date", "close"]


### PR DESCRIPTION
## Summary
- add data ingestion module using yfinance with retry and saving parquet/csv outputs
- document ingestion CLI usage
- test ingestion for schema, empty data, and file outputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5fe07c60832b90eda9d16a41572a