### PR TITLE
Add price ingestion CLI and news fetching stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ data/
 models/
 *processed_dir_path/
 .env
+# Allow package data module
+!src/sentimental_cap_predictor/data/
+!src/sentimental_cap_predictor/data/**

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,3 +15,15 @@ The CSV must contain two columns:
 - `close` – closing price for the instrument
 
 Example above runs optimizer on an NVDA CSV.
+
+## Data Ingestion
+
+Fetch price history and create optimizer-ready CSV:
+
+```bash
+python -m sentimental_cap_predictor.data.ingest NVDA --period 1Y --interval 1d
+```
+
+This saves:
+- `data/raw/NVDA_prices.parquet` with columns `date, open, high, low, close, adj_close, volume`
+- `data/processed/NVDA_prices.csv` containing only `date` and `close`

--- a/src/sentimental_cap_predictor/data/__init__.py
+++ b/src/sentimental_cap_predictor/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data utilities."""
+
+from . import ingest, news
+
+__all__ = ["ingest", "news"]

--- a/src/sentimental_cap_predictor/data/ingest.py
+++ b/src/sentimental_cap_predictor/data/ingest.py
@@ -1,0 +1,104 @@
+"""Price data ingestion and normalization utilities."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import typer
+import yfinance as yf
+from loguru import logger
+
+EXPECTED_COLUMNS = [
+    "date",
+    "open",
+    "high",
+    "low",
+    "close",
+    "adj_close",
+    "volume",
+]
+
+
+def fetch_prices(ticker: str, period: str = "5y", interval: str = "1d") -> pd.DataFrame:
+    """Fetch price data for *ticker* using yfinance.
+
+    The returned dataframe has lower-case columns and UTC-normalized ``date``.
+    Retries up to three times with exponential backoff if no data is returned.
+    """
+
+    last_error: Optional[Exception] = None
+    for attempt in range(3):
+        try:
+            logger.debug("Downloading prices for %s (attempt %d)", ticker, attempt + 1)
+            df = yf.download(
+                ticker,
+                period=period,
+                interval=interval,
+                progress=False,
+                auto_adjust=False,
+            )
+            if not df.empty:
+                break
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+        time.sleep(2**attempt)
+    else:
+        raise ValueError(f"No data returned for ticker {ticker}") from last_error
+
+    df = df.reset_index().rename(columns=str.lower)
+    if "adj close" in df.columns:
+        df = df.rename(columns={"adj close": "adj_close"})
+    df["date"] = pd.to_datetime(df["date"], utc=True)
+    df = df.drop_duplicates(subset="date").sort_values("date")
+    df = df[EXPECTED_COLUMNS]
+    df = df.astype(
+        {
+            "open": "float64",
+            "high": "float64",
+            "low": "float64",
+            "close": "float64",
+            "adj_close": "float64",
+            "volume": "int64",
+        }
+    )
+    return df
+
+
+def save_prices(df: pd.DataFrame, ticker: str) -> Path:
+    """Save raw prices to ``data/raw/{ticker}_prices.parquet``."""
+
+    raw_dir = Path("data/raw")
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    path = raw_dir / f"{ticker}_prices.parquet"
+    df.to_parquet(path, index=False)
+    return path
+
+
+def prices_to_csv_for_optimizer(df: pd.DataFrame, ticker: str) -> Path:
+    """Write close prices to ``data/processed/{ticker}_prices.csv``."""
+
+    proc_dir = Path("data/processed")
+    proc_dir.mkdir(parents=True, exist_ok=True)
+    path = proc_dir / f"{ticker}_prices.csv"
+    df[["date", "close"]].to_csv(path, index=False)
+    return path
+
+
+app = typer.Typer(help="Download and prepare price data")
+
+
+@app.command()
+def main(ticker: str, period: str = "5y", interval: str = "1d") -> None:
+    """Fetch prices and materialize parquet/CSV files."""
+
+    df = fetch_prices(ticker, period=period, interval=interval)
+    save_path = save_prices(df, ticker)
+    csv_path = prices_to_csv_for_optimizer(df, ticker)
+    typer.echo(f"Saved parquet to {save_path} and csv to {csv_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    app()

--- a/src/sentimental_cap_predictor/data/news.py
+++ b/src/sentimental_cap_predictor/data/news.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+import pandas as pd
+
+
+class NewsSource(Protocol):
+    """Protocol for news data sources."""
+
+    def fetch(self, ticker: str) -> pd.DataFrame:
+        ...
+
+
+@dataclass
+class FileSource:
+    """Read news data from a local CSV file.
+
+    The CSV is expected to contain columns ``date``, ``headline``, ``source`` and
+    optionally ``ticker``. Rows are filtered by ``ticker`` when that column is
+    present.
+    """
+
+    path: Path = Path("data/news.csv")
+
+    def fetch(self, ticker: str) -> pd.DataFrame:
+        if not self.path.exists():
+            return pd.DataFrame(columns=["date", "headline", "source"])
+        df = pd.read_csv(self.path, parse_dates=["date"])
+        if "ticker" in df.columns:
+            df = df[df["ticker"] == ticker]
+        return df[["date", "headline", "source"]]
+
+
+def fetch_news(ticker: str, source: NewsSource | None = None) -> pd.DataFrame:
+    """Fetch news headlines for ``ticker``.
+
+    Parameters
+    ----------
+    ticker:
+        Instrument symbol to fetch headlines for.
+    source:
+        Optional data source implementing :class:`NewsSource`. Defaults to
+        :class:`FileSource` reading ``data/news.csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with columns ``date``, ``headline`` and ``source``.
+    """
+
+    source = source or FileSource()
+    df = source.fetch(ticker)
+    return df[["date", "headline", "source"]]

--- a/src/sentimental_cap_predictor/prep/__init__.py
+++ b/src/sentimental_cap_predictor/prep/__init__.py
@@ -1,0 +1,13 @@
+from .pipeline import (
+    train_test_split_by_time,
+    add_returns,
+    add_tech_indicators,
+    validate_no_nans,
+)
+
+__all__ = [
+    "train_test_split_by_time",
+    "add_returns",
+    "add_tech_indicators",
+    "validate_no_nans",
+]

--- a/src/sentimental_cap_predictor/prep/pipeline.py
+++ b/src/sentimental_cap_predictor/prep/pipeline.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def train_test_split_by_time(df: pd.DataFrame, train_ratio: float = 0.7, gap: int = 5) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Split a DataFrame into train and test sets preserving time order.
+
+    A gap of ``gap`` rows is skipped between the train and test sets to avoid
+    lookahead leakage.
+    """
+    if not 0 < train_ratio < 1:
+        raise ValueError("train_ratio must be between 0 and 1")
+
+    split_idx = int(len(df) * train_ratio)
+    train = df.iloc[:split_idx].copy()
+    test = df.iloc[split_idx + gap :].copy()
+    return train.reset_index(drop=True), test.reset_index(drop=True)
+
+
+def add_returns(df: pd.DataFrame) -> pd.DataFrame:
+    """Add basic return features."""
+    df = df.copy()
+    df["ret_1d"] = df["close"].pct_change()
+    df["ret_5d"] = df["close"].pct_change(5)
+    df["log_ret"] = np.log(df["close"]).diff()
+    return df
+
+
+def add_tech_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """Add technical indicators RSI(14), MACD(12,26,9) and ATR(14)."""
+    df = df.copy()
+
+    delta = df["close"].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(14).mean()
+    avg_loss = loss.rolling(14).mean()
+    rs = avg_gain / avg_loss
+    df["rsi_14"] = 100 - (100 / (1 + rs))
+
+    ema12 = df["close"].ewm(span=12, adjust=False).mean()
+    ema26 = df["close"].ewm(span=26, adjust=False).mean()
+    macd = ema12 - ema26
+    df["macd"] = macd
+    df["macd_signal"] = macd.ewm(span=9, adjust=False).mean()
+
+    high = df["high"]
+    low = df["low"]
+    close = df["close"]
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [
+            high - low,
+            (high - prev_close).abs(),
+            (low - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+    df["atr_14"] = tr.rolling(14).mean()
+
+    return df
+
+
+def validate_no_nans(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    """Raise a ValueError if any of ``cols`` contain NaNs."""
+    missing = df[cols].isna().any()
+    if missing.any():
+        bad_cols = ", ".join(missing[missing].index.tolist())
+        raise ValueError(f"NaNs found in columns: {bad_cols}")
+    return df

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import pytest
+import yfinance as yf
+
+from sentimental_cap_predictor.data import ingest
+
+
+def _sample_download(*args, **kwargs):
+    return pd.DataFrame(
+        {
+            "Date": pd.date_range("2024-01-01", periods=2, tz="US/Eastern"),
+            "Open": [1.0, 2.0],
+            "High": [1.0, 2.0],
+            "Low": [1.0, 2.0],
+            "Close": [1.0, 2.0],
+            "Adj Close": [1.0, 2.0],
+            "Volume": [100, 200],
+        }
+    )
+
+
+def test_fetch_prices_schema(monkeypatch):
+    monkeypatch.setattr(yf, "download", _sample_download)
+    df = ingest.fetch_prices("NVDA")
+    assert list(df.columns) == ingest.EXPECTED_COLUMNS
+    assert str(df["date"].dt.tz) == "UTC"
+    assert df["volume"].dtype == "int64"
+
+
+def test_fetch_prices_empty(monkeypatch):
+    def _empty_download(*args, **kwargs):  # noqa: ANN001
+        return pd.DataFrame()
+
+    monkeypatch.setattr(yf, "download", _empty_download)
+    with pytest.raises(ValueError):
+        ingest.fetch_prices("BAD")
+
+
+def test_save_and_csv(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(yf, "download", _sample_download)
+    df = ingest.fetch_prices("NVDA")
+    raw_path = ingest.save_prices(df, "NVDA")
+    csv_path = ingest.prices_to_csv_for_optimizer(df, "NVDA")
+    assert raw_path.exists()
+    out_df = pd.read_csv(csv_path)
+    assert list(out_df.columns) == ["date", "close"]

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from sentimental_cap_predictor.data.news import FileSource, fetch_news
+
+
+def test_fetch_news_returns_columns():
+    df = fetch_news("NVDA")
+    assert list(df.columns) == ["date", "headline", "source"]
+
+
+def test_file_source_reads_csv(tmp_path):
+    csv_path = tmp_path / "news.csv"
+    pd.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            "headline": ["Example"],
+            "source": ["Test"],
+            "ticker": ["NVDA"],
+        }
+    ).to_csv(csv_path, index=False)
+
+    source = FileSource(csv_path)
+    df = source.fetch("NVDA")
+    assert len(df) == 1
+    assert df.iloc[0]["headline"] == "Example"
+    assert list(df.columns) == ["date", "headline", "source"]

--- a/tests/test_prep_pipeline.py
+++ b/tests/test_prep_pipeline.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from sentimental_cap_predictor.prep import pipeline
+
+
+def test_train_test_split_by_time_gap():
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=20),
+            "close": np.arange(20, dtype=float),
+        }
+    )
+    train, test = pipeline.train_test_split_by_time(df, train_ratio=0.5, gap=2)
+    assert len(train) == 10
+    assert len(test) == 8
+    assert test["date"].min() > train["date"].max()
+    assert (test["date"].min() - train["date"].max()).days == 3
+
+
+def test_validate_no_nans():
+    df = pd.DataFrame(
+        {
+            "close": [1, 2, 3, 4, 5],
+            "high": [1, 2, 3, 4, 5],
+            "low": [1, 2, 3, 4, 5],
+        }
+    )
+    df = pipeline.add_returns(df)
+    df = pipeline.add_tech_indicators(df)
+    with pytest.raises(ValueError):
+        pipeline.validate_no_nans(df, ["ret_1d", "rsi_14"])
+    df_clean = df.dropna()
+    pipeline.validate_no_nans(df_clean, ["ret_1d", "rsi_14"])


### PR DESCRIPTION
## Summary
- add data ingestion module using yfinance with retry and saving parquet/csv outputs
- expose news fetching stub with pluggable FileSource
- add preprocessing pipeline with time-based split, return features, and technical indicators

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5fe07c60832b90eda9d16a41572a