### PR TITLE
Avoid collecting stray test files

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+testpaths = tests
 markers =
     e2e: end-to-end tests


### PR DESCRIPTION
## Summary
- Limit pytest discovery to the `tests` directory so temporary outputs like `data/processed/test_plots.py` are ignored

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4df5dc6cc832baad534c9561ed058