### PR TITLE
Add rolling PnL risk limit enforcement

### DIFF
--- a/src/sentimental_cap_predictor/trader_utils/__init__.py
+++ b/src/sentimental_cap_predictor/trader_utils/__init__.py
@@ -1,3 +1,5 @@
 """Trading utility modules."""
 
-__all__ = []
+from .risk import enforce_limits
+
+__all__ = ["enforce_limits"]

--- a/src/sentimental_cap_predictor/trader_utils/risk.py
+++ b/src/sentimental_cap_predictor/trader_utils/risk.py
@@ -1,0 +1,70 @@
+"""Risk management utilities.
+
+This module currently provides an ``enforce_limits`` function which monitors
+rolling profit and loss (PnL) and emits a trading state of ``"FLAT"`` when
+predefined limits are breached.  Once a breach occurs the state remains
+``"FLAT"`` for all subsequent observations.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable
+
+
+def enforce_limits(
+    pnl: Iterable[float],
+    window: int,
+    loss_limit: float,
+    profit_limit: float | None = None,
+) -> list[str]:
+    """Monitor rolling PnL and emit trading state on limit breaches.
+
+    Parameters
+    ----------
+    pnl:
+        Iterable of profit and loss values over time.
+    window:
+        Number of recent observations to include in the rolling calculation.
+    loss_limit:
+        Maximum allowed cumulative loss over the rolling window. Must be
+        positive.
+    profit_limit:
+        Optional profit target. If provided and the rolling PnL exceeds this
+        value, the state transitions to ``"FLAT"``.  The default is ``None``
+        which disables the profit check.
+
+    Returns
+    -------
+    list[str]
+        Sequence of trading states corresponding to each PnL observation.
+        Values are either ``"LIVE"`` or ``"FLAT"``. Once ``"FLAT"`` it remains
+        ``"FLAT"`` for all subsequent points.
+    """
+    if window <= 0:
+        raise ValueError("window must be positive")
+    if loss_limit <= 0:
+        raise ValueError("loss_limit must be positive")
+    if profit_limit is not None and profit_limit <= 0:
+        raise ValueError("profit_limit must be positive when provided")
+
+    recent = deque()
+    rolling_total = 0.0
+    flat = False
+    states: list[str] = []
+
+    for value in pnl:
+        recent.append(value)
+        rolling_total += value
+        if len(recent) > window:
+            rolling_total -= recent.popleft()
+
+        if not flat:
+            if rolling_total <= -loss_limit or (
+                profit_limit is not None and rolling_total >= profit_limit
+            ):
+                flat = True
+
+        states.append("FLAT" if flat else "LIVE")
+
+    return states

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,20 @@
+from sentimental_cap_predictor.trader_utils.risk import enforce_limits
+
+
+def test_enforce_limits_no_breach():
+    pnl = [1.0, -1.0, 2.0, -0.5]
+    states = enforce_limits(pnl, window=3, loss_limit=10.0)
+    assert states == ["LIVE", "LIVE", "LIVE", "LIVE"]
+
+
+def test_enforce_limits_loss_breach_sets_flat():
+    pnl = [10.0, -5.0, -5.0, -5.0, 2.0]
+    states = enforce_limits(pnl, window=3, loss_limit=10.0)
+    assert states[3] == "FLAT"
+    assert states[3:] == ["FLAT", "FLAT"]
+
+
+def test_enforce_limits_profit_breach_sets_flat():
+    pnl = [4.0, 4.0, 4.0]
+    states = enforce_limits(pnl, window=3, loss_limit=10.0, profit_limit=10.0)
+    assert states == ["LIVE", "LIVE", "FLAT"]


### PR DESCRIPTION
## Summary
- add `enforce_limits` utility to monitor rolling PnL and signal `FLAT` on breaches
- expose `enforce_limits` in `trader_utils` package
- test loss and profit limit behaviour

## Testing
- `ruff check tests/test_risk.py src/sentimental_cap_predictor/trader_utils/risk.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ec97ced4832b9174e2f60ff13de1