### PR TITLE
chore: add common formatting hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,18 @@
 repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.5
+    rev: v0.12.9
     hooks:
       - id: ruff
       - id: ruff-format


### PR DESCRIPTION
## Summary
- add black, isort, and flake8 hooks to pre-commit config
- lock hook versions via pre-commit autoupdate

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4f4ccc3ac832b9eb3d3dc5ccb4112