### PR TITLE
Add research objectives and constraints utilities

### DIFF
--- a/src/sentimental_cap_predictor/research/constraints.py
+++ b/src/sentimental_cap_predictor/research/constraints.py
@@ -1,0 +1,53 @@
+"""Constraint helper functions used to filter backtest results."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .types import BacktestResult
+
+
+def max_drawdown(
+    result: "BacktestResult",
+    limit: float = 0.25,
+) -> tuple[bool, str]:
+    """Check that maximum drawdown does not exceed ``limit``."""
+
+    equity = result.equity_curve.astype(float)
+    cumulative_max = equity.cummax()
+    drawdown = equity / cumulative_max - 1.0
+    maxdd = float(drawdown.min())
+    ok = maxdd >= -limit
+    status = "within" if ok else "exceeds"
+    msg = f"Max drawdown {maxdd:.2%} {status} limit {limit:.2%}"
+    return ok, msg
+
+
+def min_trades(result: "BacktestResult", n: int = 30) -> tuple[bool, str]:
+    """Ensure at least ``n`` trades were executed."""
+
+    count = len(result.trades)
+    ok = count >= n
+    msg = f"{count} trades {'meets' if ok else 'below'} minimum {n}"
+    return ok, msg
+
+
+def max_turnover(
+    result: "BacktestResult",
+    limit: float = 5.0,
+) -> tuple[bool, str]:
+    """Check that portfolio turnover is within ``limit``."""
+
+    positions = result.positions
+    if isinstance(positions, pd.DataFrame):
+        turnover = float(positions.diff().abs().sum().sum())
+    else:
+        turnover = float(positions.diff().abs().sum())
+
+    ok = turnover <= limit
+    status = "within" if ok else "exceeds"
+    msg = f"Turnover {turnover:.2f} {status} limit {limit:.2f}"
+    return ok, msg

--- a/src/sentimental_cap_predictor/research/objectives.py
+++ b/src/sentimental_cap_predictor/research/objectives.py
@@ -1,0 +1,60 @@
+"""Objective functions evaluating backtest performance.
+
+These helpers operate on
+:class:`~sentimental_cap_predictor.research.types.BacktestResult` instances
+and compute common risk-adjusted metrics.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .types import BacktestResult
+
+
+def _returns(result: "BacktestResult") -> pd.Series:
+    """Return daily percentage returns of the equity curve."""
+
+    equity = result.equity_curve.astype(float)
+    return equity.pct_change().dropna()
+
+
+def sharpe(result: "BacktestResult") -> float:
+    """Annualised Sharpe ratio of ``result``."""
+
+    rets = _returns(result)
+    vol = rets.std(ddof=0)
+    if vol == 0:
+        return float("nan")
+    return float(np.sqrt(252) * rets.mean() / vol)
+
+
+def sortino(result: "BacktestResult") -> float:
+    """Annualised Sortino ratio using downside deviation."""
+
+    rets = _returns(result)
+    downside = rets[rets < 0]
+    dd = downside.std(ddof=0)
+    if dd == 0:
+        return float("nan")
+    return float(np.sqrt(252) * rets.mean() / dd)
+
+
+def calmar(result: "BacktestResult") -> float:
+    """Calmar ratio defined as CAGR divided by max drawdown."""
+
+    equity = result.equity_curve.astype(float)
+    n = len(equity)
+    if n == 0:
+        return float("nan")
+    cagr = float(equity.iloc[-1] ** (252 / n) - 1)
+    cumulative_max = equity.cummax()
+    drawdown = equity / cumulative_max - 1.0
+    maxdd = float(drawdown.min())
+    if maxdd == 0:
+        return float("nan")
+    return cagr / abs(maxdd)


### PR DESCRIPTION
## Summary
- add objective functions for Sharpe, Sortino, and Calmar ratios
- add constraint helpers for drawdown, trade count, and turnover limits

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/research/objectives.py src/sentimental_cap_predictor/research/constraints.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a50f34a62c832ba772000acff1a2a0