### PR TITLE
Use stored strategy returns for risk metrics

### DIFF
--- a/src/sentimental_cap_predictor/research/objectives.py
+++ b/src/sentimental_cap_predictor/research/objectives.py
@@ -17,10 +17,14 @@ if TYPE_CHECKING:  # pragma: no cover - for type checkers only
 
 
 def _returns(result: "BacktestResult") -> pd.Series:
-    """Return daily percentage returns of the equity curve."""
+    """Return daily strategy returns.
 
-    equity = result.equity_curve.astype(float)
-    return equity.pct_change().dropna()
+    Returns are retrieved from ``result.artifacts['strat_ret']`` which
+    contains the backtest's daily percentage returns.
+    """
+
+    rets = pd.Series(result.artifacts["strat_ret"], dtype=float)
+    return rets.dropna()
 
 
 def sharpe(result: "BacktestResult") -> float:
@@ -51,7 +55,7 @@ def calmar(result: "BacktestResult") -> float:
     n = len(equity)
     if n == 0:
         return float("nan")
-    cagr = float(equity.iloc[-1] ** (252 / n) - 1)
+    cagr = float((equity.iloc[-1] / equity.iloc[0]) ** (252 / n) - 1)
     cumulative_max = equity.cummax()
     drawdown = equity / cumulative_max - 1.0
     maxdd = float(drawdown.min())

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from sentimental_cap_predictor.research import objectives
+from sentimental_cap_predictor.research.types import BacktestResult
+
+
+def _make_result(returns: pd.Series, equity: pd.Series) -> BacktestResult:
+    return BacktestResult(
+        idea_name="test",
+        equity_curve=equity,
+        trades=[],
+        positions=pd.Series(dtype=float),
+        metrics={},
+        artifacts={"strat_ret": returns},
+    )
+
+
+def test_sharpe_and_sortino_use_artifact_returns():
+    returns = pd.Series([0.02, -0.01, 0.03, -0.02])
+    equity = pd.Series(1.0, index=returns.index)  # flat equity
+    result = _make_result(returns, equity)
+
+    expected_sharpe = np.sqrt(252) * returns.mean() / returns.std(ddof=0)
+    downside = returns[returns < 0].std(ddof=0)
+    expected_sortino = np.sqrt(252) * returns.mean() / downside
+
+    assert objectives.sharpe(result) == pytest.approx(expected_sharpe)
+    assert objectives.sortino(result) == pytest.approx(expected_sortino)
+
+
+def test_calmar_uses_equity_curve():
+    returns = pd.Series([0.02, -0.01, 0.03, -0.02])
+    equity = (1 + returns).cumprod()
+    result = _make_result(returns, equity)
+
+    n = len(equity)
+    cagr = (equity.iloc[-1] / equity.iloc[0]) ** (252 / n) - 1
+    cumulative_max = equity.cummax()
+    drawdown = equity / cumulative_max - 1.0
+    maxdd = abs(drawdown.min())
+    expected_calmar = cagr / maxdd
+
+    assert objectives.calmar(result) == pytest.approx(expected_calmar)


### PR DESCRIPTION
## Summary
- derive Sharpe and Sortino ratios from daily returns in `result.artifacts['strat_ret']`
- compute Calmar ratio using CAGR and absolute max drawdown from the equity curve
- add regression tests for objective metrics

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/research/objectives.py tests/test_objectives.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a519745180832bbfe1ed9009fb10ff