### PR TITLE
Add research regression tests

### DIFF
--- a/tests/research/test_bundle_alignment.py
+++ b/tests/research/test_bundle_alignment.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from sentimental_cap_predictor.data.loader import align_daily, align_pit_fundamentals
+
+
+def test_align_daily_forward_fill_limit():
+    index = pd.date_range('2020-01-01', periods=35, freq='D')
+    df = pd.DataFrame({'score': [1.0]}, index=[index[0]])
+    aligned = align_daily(df, index)
+    assert aligned.loc[index[1], 'score'] == 1.0
+    assert aligned.loc[index[30], 'score'] == 1.0
+    assert pd.isna(aligned.loc[index[31], 'score'])
+
+
+def test_align_pit_fundamentals_forward_fill():
+    index = pd.date_range('2020-01-01', periods=5, freq='D')
+    fundamentals = pd.DataFrame({
+        'date': [pd.Timestamp('2020-01-01'), pd.Timestamp('2020-01-02')],
+        'field': ['metric', 'metric'],
+        'value': [10.0, 20.0],
+        'asof_ts': [pd.Timestamp('2020-01-03'), pd.Timestamp('2020-01-04')],
+    })
+    aligned = align_pit_fundamentals(fundamentals, index)
+    assert pd.isna(aligned.loc['2020-01-02', 'metric'])
+    assert aligned.loc['2020-01-03', 'metric'] == 10.0
+    assert aligned.loc['2020-01-04', 'metric'] == 20.0

--- a/tests/research/test_engine_accounting.py
+++ b/tests/research/test_engine_accounting.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import pytest
+
+from sentimental_cap_predictor.research.engine import simple_backtester
+from sentimental_cap_predictor.research.types import BacktestContext, DataBundle
+from sentimental_cap_predictor.research.idea_schema import Idea
+
+
+class AlwaysLong:
+    def generate_signals(self, data, idea):
+        return pd.Series(1.0, index=data.prices.index)
+
+
+def test_constant_weight_pnl_and_cost_impact():
+    index = pd.date_range('2020-01-01', periods=3, freq='D')
+    prices = pd.DataFrame({'open': [100, 100, 100], 'close': [101, 101, 101]}, index=index)
+    data = DataBundle(prices=prices)
+    idea = Idea(name='long')
+    ctx = BacktestContext(fees_bps=1, slip_bps=2)
+
+    backtester = simple_backtester(AlwaysLong())
+    result = backtester(data, idea, ctx)
+
+    cost = (ctx.fees_bps + ctx.slip_bps) / 1e4
+    expected_equity = (1.0) * (1 + 0) * (1 + 0.01 - cost) * (1 + 0.01)
+    assert result.equity_curve.iloc[-1] == pytest.approx(expected_equity)
+    assert len(result.trades) == 1
+    assert result.trades[0].fees == pytest.approx(cost)
+

--- a/tests/research/test_optimize.py
+++ b/tests/research/test_optimize.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+
+from research.optimize import grid_optimize
+from research.search_space import ParamSpec
+
+
+def test_optimizer_selects_best_sharpe():
+    space = {'p': ParamSpec(kind='choice', choices=[1, 2, 3])}
+
+    def backtest(idea, data, ctx):
+        return SimpleNamespace(metrics={'Sharpe': idea['p']})
+
+    def objective(result):
+        return result.metrics['Sharpe']
+
+    best_idea, _ = grid_optimize({}, backtest, None, None, space, objective)
+    assert best_idea['p'] == 3
+

--- a/tests/research/test_sandbox.py
+++ b/tests/research/test_sandbox.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import pytest
+
+from research.sandbox import SandboxError, run_strategy_source
+from sentimental_cap_predictor.research.idea_schema import Idea
+from sentimental_cap_predictor.research.types import DataBundle
+
+
+def test_forbidden_import_raises_sandbox_error():
+    index = pd.date_range('2020-01-01', periods=1, freq='D')
+    prices = pd.DataFrame({'close': [1.0]}, index=index)
+    data = DataBundle(prices=prices)
+    idea = Idea(name='x')
+    source = "import os\nstrategy = None"
+    with pytest.raises(SandboxError):
+        run_strategy_source(source, data, idea)
+

--- a/tests/research/test_strategy_contract.py
+++ b/tests/research/test_strategy_contract.py
@@ -1,0 +1,25 @@
+import inspect
+import re
+
+import pandas as pd
+
+from sentimental_cap_predictor.research.engine import SmaSentStrategy
+from sentimental_cap_predictor.research.idea_schema import Idea
+from sentimental_cap_predictor.research.types import DataBundle
+
+
+def test_signal_alignment_and_bounds_and_no_shift():
+    index = pd.date_range('2020-01-01', periods=5, freq='D')
+    prices = pd.DataFrame({'close': range(1, 6)}, index=index)
+    sentiment = pd.DataFrame({'score': [0, 1, 0.5, 1, 0]}, index=index)
+    data = DataBundle(prices=prices, sentiment=sentiment)
+    idea = Idea(name='sma', params={'ma_window': 2, 'sent_thr': 0.3})
+    strat = SmaSentStrategy()
+
+    signals = strat.generate_signals(data, idea)
+    assert signals.index.equals(prices.index)
+    assert ((signals >= 0) & (signals <= 1)).all()
+
+    src = inspect.getsource(SmaSentStrategy.generate_signals)
+    assert re.search(r"shift\s*\(\s*-1\s*\)", src) is None
+


### PR DESCRIPTION
## Summary
- add loader alignment tests for daily data and point-in-time fundamentals
- verify backtester accounting for constant positions and transaction costs
- ensure strategy signals align, stay within bounds, and avoid look-ahead
- check sandbox rejects forbidden imports
- confirm optimizer selects parameter with highest Sharpe

## Testing
- `pytest tests/research -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5257b8f68832baf4b080fcf5cc523