### PR TITLE
feat: add backtesting infrastructure and sandboxed execution

### DIFF
--- a/src/sentimental_cap_predictor/backtest_result.py
+++ b/src/sentimental_cap_predictor/backtest_result.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Dict
+
+import pandas as pd
+
+
+@dataclass
+class BacktestResult:
+    """Holds the outputs of a backtest run."""
+
+    trades: pd.DataFrame
+    equity_curve: pd.Series
+    metrics: Dict[str, float]

--- a/src/sentimental_cap_predictor/backtester.py
+++ b/src/sentimental_cap_predictor/backtester.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+from .data_bundle import DataBundle
+from .strategy import StrategyIdea
+from .backtest_result import BacktestResult
+from .evaluation import compute_metrics
+
+
+def backtest(
+    data: DataBundle,
+    strategy: StrategyIdea,
+    initial_capital: float = 1_000_000.0,
+    cost_per_trade: float = 0.0,
+    slippage: float = 0.0,
+) -> BacktestResult:
+    """Run a minimal backtest for ``strategy`` using ``data``.
+
+    Signals are interpreted as target position (number of units) in the first
+    column of ``data.prices``.  Trades are executed at the same bar with optional
+    fixed transaction cost and proportional slippage.
+    """
+
+    prices = data.prices.iloc[:, 0]
+    signals = strategy.generate_signals(data).reindex(prices.index).fillna(0)
+
+    position = 0.0
+    cash = initial_capital
+    equity_curve = []
+    trades = []
+
+    for date, price in prices.items():
+        desired = signals.loc[date]
+        if desired != position:
+            trade_size = desired - position
+            trade_price = price * (1 + slippage if trade_size > 0 else 1 - slippage)
+            cash -= trade_size * trade_price
+            cash -= cost_per_trade
+            trades.append({"date": date, "size": trade_size, "price": trade_price})
+            position = desired
+        equity_curve.append({"date": date, "equity": cash + position * price})
+
+    equity_series = pd.Series([e["equity"] for e in equity_curve], index=prices.index)
+    trades_df = pd.DataFrame(trades)
+    metrics = compute_metrics(equity_series, trades_df)
+    return BacktestResult(trades=trades_df, equity_curve=equity_series, metrics=metrics)

--- a/src/sentimental_cap_predictor/data_bundle.py
+++ b/src/sentimental_cap_predictor/data_bundle.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import pandas as pd
+
+
+@dataclass
+class DataBundle:
+    """Container for point-in-time market and sentiment data.
+
+    All data frames must share the same :class:`~pandas.DatetimeIndex` and be
+    aligned so that strategies cannot accidentally access future information.
+    """
+
+    prices: pd.DataFrame
+    features: Optional[pd.DataFrame] = None
+    sentiment: Optional[pd.DataFrame] = None
+    metadata: Optional[Dict[str, object]] = None
+
+    def validate(self) -> "DataBundle":
+        """Validate that all included data are aligned by timestamp.
+
+        Returns the bundle itself so callers can use ``bundle.validate()`` when
+        constructing the object.  The check is intentionally lightweight – it
+        ensures that all frames share the same, monotonically increasing
+        ``DatetimeIndex`` and that no timestamps lie in the future.
+        """
+
+        base_index = self.prices.index
+        if not isinstance(base_index, pd.DatetimeIndex):
+            raise ValueError("prices must be indexed by pandas.DatetimeIndex")
+        if not base_index.is_monotonic_increasing:
+            raise ValueError("prices index must be sorted chronologically")
+        if (base_index > pd.Timestamp.utcnow()).any():
+            raise ValueError("prices contain timestamps in the future")
+
+        for frame in (self.features, self.sentiment):
+            if frame is None:
+                continue
+            if not isinstance(frame.index, pd.DatetimeIndex):
+                raise ValueError("all DataFrames must use pandas.DatetimeIndex")
+            if not frame.index.equals(base_index):
+                raise ValueError("DataFrames must be aligned on the same index")
+            if (frame.index > pd.Timestamp.utcnow()).any():
+                raise ValueError("data contains timestamps in the future")
+        return self
+

--- a/src/sentimental_cap_predictor/evaluation.py
+++ b/src/sentimental_cap_predictor/evaluation.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class Constraints:
+    """Hard limits applied to strategy evaluation."""
+
+    max_drawdown: float = 0.2  # 20%
+    min_trades: int = 30
+
+
+def sharpe_ratio(returns: pd.Series, risk_free: float = 0.0, periods_per_year: int = 252) -> float:
+    """Compute the annualised Sharpe ratio for a series of returns."""
+
+    if returns.std(ddof=0) == 0:
+        return 0.0
+    excess = returns - risk_free / periods_per_year
+    return np.sqrt(periods_per_year) * excess.mean() / excess.std(ddof=0)
+
+
+def max_drawdown(equity: pd.Series) -> float:
+    """Return the maximum drawdown of an equity curve."""
+
+    running_max = equity.cummax()
+    drawdown = (equity - running_max) / running_max
+    return drawdown.min()
+
+
+def compute_metrics(equity: pd.Series, trades: pd.DataFrame) -> Dict[str, float]:
+    returns = equity.pct_change().dropna()
+    metrics = {
+        "total_return": equity.iloc[-1] / equity.iloc[0] - 1,
+        "sharpe_ratio": sharpe_ratio(returns),
+        "max_drawdown": max_drawdown(equity),
+        "trade_count": len(trades),
+    }
+    return metrics
+
+
+def objective(metrics: Dict[str, float]) -> float:
+    """Simple objective function: risk-adjusted return via Sharpe ratio."""
+
+    return metrics.get("sharpe_ratio", 0.0)
+
+
+def passes_constraints(metrics: Dict[str, float], constraints: Constraints | None = None) -> bool:
+    constraints = constraints or Constraints()
+    if metrics.get("trade_count", 0) < constraints.min_trades:
+        return False
+    if abs(metrics.get("max_drawdown", 0)) > constraints.max_drawdown:
+        return False
+    return True

--- a/src/sentimental_cap_predictor/experiment.py
+++ b/src/sentimental_cap_predictor/experiment.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+from typing import Dict, Any
+
+from loguru import logger
+
+DB_PATH = Path("experiments.db")
+
+
+class ExperimentTracker:
+    """Very small SQLite-based experiment tracker."""
+
+    def __init__(self, db_path: Path = DB_PATH) -> None:
+        self.conn = sqlite3.connect(db_path)
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                code_hash TEXT,
+                params TEXT,
+                metrics TEXT,
+                artifacts TEXT,
+                timestamp TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        self.conn.commit()
+
+    def log(self, code: str, params: Dict[str, Any], metrics: Dict[str, float], artifacts: Dict[str, str]) -> None:
+        code_hash = hashlib.sha256(code.encode()).hexdigest()
+        self.conn.execute(
+            "INSERT INTO runs(code_hash, params, metrics, artifacts) VALUES (?, ?, ?, ?)",
+            (
+                code_hash,
+                json.dumps(params, default=str),
+                json.dumps(metrics, default=str),
+                json.dumps(artifacts, default=str),
+            ),
+        )
+        self.conn.commit()
+        logger.info("Logged experiment with hash %s", code_hash)

--- a/src/sentimental_cap_predictor/sandbox.py
+++ b/src/sentimental_cap_predictor/sandbox.py
@@ -1,0 +1,48 @@
+"""Execute untrusted strategy code in a restricted sandbox."""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import multiprocessing as mp
+from typing import Dict
+
+ALLOWED_MODULES = {"pandas", "numpy"}
+SAFE_BUILTINS = {name: getattr(builtins, name) for name in [
+    "abs",
+    "float",
+    "int",
+    "len",
+    "min",
+    "max",
+    "range",
+]}
+
+
+def _exec(code: str, queue: mp.Queue) -> None:
+    env: Dict[str, object] = {"__builtins__": SAFE_BUILTINS}
+    exec(code, env)
+    queue.put(env)
+
+
+def _validate(code: str) -> None:
+    tree = ast.parse(code)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            module = node.names[0].name.split(".")[0]
+            if module not in ALLOWED_MODULES:
+                raise ValueError(f"Import of module '{module}' is not allowed")
+
+
+def run_code(code: str, timeout: int = 5) -> Dict[str, object]:
+    """Run ``code`` in a subprocess with limited builtins and imports."""
+
+    _validate(code)
+    queue: mp.Queue = mp.Queue()
+    proc = mp.Process(target=_exec, args=(code, queue))
+    proc.start()
+    proc.join(timeout)
+    if proc.is_alive():
+        proc.terminate()
+        raise TimeoutError("Strategy execution timed out")
+    return queue.get() if not queue.empty() else {}

--- a/src/sentimental_cap_predictor/strategy.py
+++ b/src/sentimental_cap_predictor/strategy.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import pandas as pd
+
+from .data_bundle import DataBundle
+
+
+class StrategyIdea(ABC):
+    """Abstract base class for model-generated strategies."""
+
+    @abstractmethod
+    def generate_signals(self, data: DataBundle) -> pd.Series:
+        """Return target position signals indexed by date."""
+        raise NotImplementedError
+
+
+class BuyAndHoldStrategy(StrategyIdea):
+    """Simple example strategy used as guidance for LLM-generated code."""
+
+    def generate_signals(self, data: DataBundle) -> pd.Series:  # pragma: no cover - trivial
+        return pd.Series(1, index=data.prices.index)


### PR DESCRIPTION
## Summary
- add DataBundle, Strategy interface, and minimal backtesting engine
- implement evaluation utilities with constraints and experiment tracking
- sandbox strategy execution to restrict imports and resources

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a527605b4c832bab39c2f20aa38821