### PR TITLE
Add helper accessors and publication timestamp validation for DataBundle

### DIFF
--- a/docs/data_bundle.md
+++ b/docs/data_bundle.md
@@ -1,0 +1,21 @@
+# Data Bundle Format
+
+A `DataBundle` groups time-aligned market and alternative data used by the
+library.  All contained :class:`pandas.DataFrame` instances must share the same
+`DatetimeIndex`.
+
+For **multi‑asset** bundles the columns should use a two‑level
+:class:`pandas.MultiIndex` with the first level being the asset identifier and
+the second level the field name.  A price DataFrame for two tickers might look
+like:
+
+```
+index               AAPL                  MSFT
+                     open  close         open  close
+2024‑01‑01            ...   ...           ...   ...
+2024‑01‑02            ...   ...           ...   ...
+```
+
+Single‑asset bundles may keep a flat column index with only field names.  Any
+optional publication timestamps must mirror the shape of the corresponding data
+frames and must not be later than the data's timestamp.

--- a/src/sentimental_cap_predictor/data_bundle.py
+++ b/src/sentimental_cap_predictor/data_bundle.py
@@ -12,12 +12,66 @@ class DataBundle:
 
     All data frames must share the same :class:`~pandas.DatetimeIndex` and be
     aligned so that strategies cannot accidentally access future information.
+
+    For multi-asset bundles each data frame is expected to use a two-level
+    :class:`~pandas.MultiIndex` on the columns where the first level contains
+    the asset identifier and the second level contains the field name, e.g.
+    ``('AAPL', 'close')``.  Single-asset bundles may use a flat column index.
     """
 
     prices: pd.DataFrame
     features: Optional[pd.DataFrame] = None
     sentiment: Optional[pd.DataFrame] = None
+    publication_times: Optional[Dict[str, pd.DataFrame]] = None
     metadata: Optional[Dict[str, object]] = None
+
+    # ------------------------------------------------------------------
+    # Convenience data accessors
+    # ------------------------------------------------------------------
+    def _get_from_frame(self, frame: pd.DataFrame, asset: str, field: str) -> pd.Series:
+        """Extract a series from ``frame`` for ``asset`` and ``field``.
+
+        Parameters
+        ----------
+        frame:
+            The data frame to query.
+        asset:
+            Asset identifier such as a ticker symbol.
+        field:
+            Column/field name to retrieve for the asset.
+        """
+
+        if isinstance(frame.columns, pd.MultiIndex):
+            try:
+                return frame[(asset, field)]
+            except KeyError as exc:  # pragma: no cover - defensive
+                raise KeyError(f"{asset}/{field} not found") from exc
+
+        # Single asset; rely on metadata to ensure the requested asset matches
+        if self.metadata and self.metadata.get("ticker") not in (None, asset):
+            raise KeyError(f"asset {asset} not available")
+        if field not in frame.columns:
+            raise KeyError(f"{field} not found for {asset}")
+        return frame[field]
+
+    def get_series(self, asset: str, field: str) -> pd.Series:
+        """Return a price series for ``asset`` and ``field``."""
+
+        return self._get_from_frame(self.prices, asset, field)
+
+    def get_feature(self, asset: str, field: str) -> pd.Series:
+        """Return a feature series for ``asset`` and ``field``."""
+
+        if self.features is None:
+            raise KeyError("no features available")
+        return self._get_from_frame(self.features, asset, field)
+
+    def get_sentiment(self, asset: str, field: str) -> pd.Series:
+        """Return a sentiment/alternative data series."""
+
+        if self.sentiment is None:
+            raise KeyError("no sentiment data available")
+        return self._get_from_frame(self.sentiment, asset, field)
 
     def validate(self) -> "DataBundle":
         """Validate that all included data are aligned by timestamp.
@@ -33,17 +87,39 @@ class DataBundle:
             raise ValueError("prices must be indexed by pandas.DatetimeIndex")
         if not base_index.is_monotonic_increasing:
             raise ValueError("prices index must be sorted chronologically")
-        if (base_index > pd.Timestamp.utcnow()).any():
+        now = pd.Timestamp.utcnow().tz_localize(None)
+        if (base_index > now).any():
             raise ValueError("prices contain timestamps in the future")
 
-        for frame in (self.features, self.sentiment):
+        frames = {
+            "prices": self.prices,
+            "features": self.features,
+            "sentiment": self.sentiment,
+        }
+        for name, frame in frames.items():
             if frame is None:
                 continue
             if not isinstance(frame.index, pd.DatetimeIndex):
                 raise ValueError("all DataFrames must use pandas.DatetimeIndex")
             if not frame.index.equals(base_index):
                 raise ValueError("DataFrames must be aligned on the same index")
-            if (frame.index > pd.Timestamp.utcnow()).any():
+            if (frame.index > now).any():
                 raise ValueError("data contains timestamps in the future")
+
+            if self.publication_times and name in self.publication_times:
+                pub_df = self.publication_times[name]
+                if not isinstance(pub_df.index, pd.DatetimeIndex):
+                    raise ValueError("publication timestamps must use pandas.DatetimeIndex")
+                if not pub_df.index.equals(base_index):
+                    raise ValueError("publication timestamps must align with data index")
+                if not pub_df.columns.equals(frame.columns):
+                    raise ValueError("publication timestamps must align with data columns")
+                for col in pub_df.columns:
+                    series = pub_df[col]
+                    if (series > now).any():
+                        raise ValueError("publication timestamps in the future")
+                    if (series > base_index).any():
+                        raise ValueError("publication timestamp after data timestamp detected")
+
         return self
 

--- a/tests/test_data_bundle.py
+++ b/tests/test_data_bundle.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pytest
+
+from sentimental_cap_predictor.data_bundle import DataBundle
+
+
+def test_get_series_and_convenience_access():
+    index = pd.date_range('2024-01-01', periods=3, freq='D')
+    prices = pd.DataFrame({
+        ('AAPL', 'close'): [1, 2, 3],
+        ('MSFT', 'close'): [2, 3, 4],
+    }, index=index)
+    features = pd.DataFrame({('AAPL', 'feat'): [0.1, 0.2, 0.3]}, index=index)
+    sentiment = pd.DataFrame({('AAPL', 'score'): [0.5, 0.6, 0.7]}, index=index)
+
+    bundle = DataBundle(prices=prices, features=features, sentiment=sentiment).validate()
+
+    pd.testing.assert_series_equal(bundle.get_series('AAPL', 'close'), prices[('AAPL', 'close')])
+    pd.testing.assert_series_equal(bundle.get_feature('AAPL', 'feat'), features[('AAPL', 'feat')])
+    pd.testing.assert_series_equal(bundle.get_sentiment('AAPL', 'score'), sentiment[('AAPL', 'score')])
+
+
+def test_publication_timestamps_enforce_no_lookahead():
+    index = pd.date_range('2024-01-01', periods=2, freq='D')
+    prices = pd.DataFrame({('AAPL', 'close'): [1, 2]}, index=index)
+    pub_ok = pd.DataFrame({('AAPL', 'close'): index - pd.Timedelta(hours=1)}, index=index)
+
+    # Should validate successfully
+    DataBundle(prices=prices, publication_times={'prices': pub_ok}).validate()
+
+    pub_bad = pd.DataFrame({('AAPL', 'close'): index + pd.Timedelta(days=1)}, index=index)
+    with pytest.raises(ValueError):
+        DataBundle(prices=prices, publication_times={'prices': pub_bad}).validate()


### PR DESCRIPTION
## Summary
- add `get_series`, `get_feature`, and `get_sentiment` helpers to `DataBundle`
- support optional per-field publication timestamps and verify no future leaks
- document expected multi-asset column layout and provide dedicated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52c0ec604832b928114ad760117c8