### PR TITLE
Enhance backtest result with trade analytics

### DIFF
--- a/src/sentimental_cap_predictor/backtest_result.py
+++ b/src/sentimental_cap_predictor/backtest_result.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict
+from typing import Any, Dict
 
 import pandas as pd
 
@@ -11,3 +11,17 @@ class BacktestResult:
     trades: pd.DataFrame
     equity_curve: pd.Series
     metrics: Dict[str, float]
+    parameters: Dict[str, Any]
+    trade_pnls: pd.Series
+    holding_periods: pd.Series
+
+    def return_series(self) -> pd.Series:
+        """Return the periodic returns derived from the equity curve."""
+        return self.equity_curve.pct_change().fillna(0)
+
+    def export_trades(self, path: str) -> None:
+        """Export the trade log to ``path`` as CSV."""
+        export_df = self.trades.copy()
+        if len(self.trade_pnls) == len(export_df):
+            export_df = export_df.assign(pnl=self.trade_pnls, holding_period=self.holding_periods)
+        export_df.to_csv(path, index=False)


### PR DESCRIPTION
## Summary
- extend `BacktestResult` to include strategy parameters, per-trade PnL and holding periods
- add helper methods for return series and exporting trade logs
- update backtester to compute trade-level analytics and populate new result fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a52fc25ae0832b996669b019415a65