### PR TITLE
Enhance strategy evaluation and ranking

### DIFF
--- a/src/sentimental_cap_predictor/evaluation.py
+++ b/src/sentimental_cap_predictor/evaluation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Iterable
 
 import numpy as np
 import pandas as pd
@@ -9,10 +9,15 @@ import pandas as pd
 
 @dataclass
 class Constraints:
-    """Hard limits applied to strategy evaluation."""
+    """Hard limits applied to strategy evaluation.
 
-    max_drawdown: float = 0.2  # 20%
-    min_trades: int = 30
+    Parameters can be set to ``None`` to disable a particular constraint.
+    """
+
+    max_drawdown: float | None = 0.2  # 20%
+    min_trades: int | None = 30
+    max_volatility: float | None = None
+    max_turnover: float | None = None
 
 
 def sharpe_ratio(returns: pd.Series, risk_free: float = 0.0, periods_per_year: int = 252) -> float:
@@ -22,6 +27,24 @@ def sharpe_ratio(returns: pd.Series, risk_free: float = 0.0, periods_per_year: i
         return 0.0
     excess = returns - risk_free / periods_per_year
     return np.sqrt(periods_per_year) * excess.mean() / excess.std(ddof=0)
+
+
+def sortino_ratio(returns: pd.Series, risk_free: float = 0.0, periods_per_year: int = 252) -> float:
+    """Compute the annualised Sortino ratio for a series of returns."""
+
+    downside = returns[returns < 0]
+    if downside.std(ddof=0) == 0:
+        return 0.0
+    excess = returns - risk_free / periods_per_year
+    return np.sqrt(periods_per_year) * excess.mean() / downside.std(ddof=0)
+
+
+def annualised_volatility(returns: pd.Series, periods_per_year: int = 252) -> float:
+    """Return the annualised volatility of ``returns``."""
+
+    if returns.empty:
+        return 0.0
+    return returns.std(ddof=0) * np.sqrt(periods_per_year)
 
 
 def max_drawdown(equity: pd.Series) -> float:
@@ -34,25 +57,120 @@ def max_drawdown(equity: pd.Series) -> float:
 
 def compute_metrics(equity: pd.Series, trades: pd.DataFrame) -> Dict[str, float]:
     returns = equity.pct_change().dropna()
+    turnover = 0.0
+    if not trades.empty:
+        turnover = (trades["size"].abs() * trades["entry_price"].abs()).sum() / float(
+            equity.iloc[0]
+        )
     metrics = {
         "total_return": equity.iloc[-1] / equity.iloc[0] - 1,
         "sharpe_ratio": sharpe_ratio(returns),
+        "sortino_ratio": sortino_ratio(returns),
+        "volatility": annualised_volatility(returns),
+        "turnover": turnover,
         "max_drawdown": max_drawdown(equity),
         "trade_count": len(trades),
     }
     return metrics
 
 
-def objective(metrics: Dict[str, float]) -> float:
-    """Simple objective function: risk-adjusted return via Sharpe ratio."""
+def objective(
+    metrics: Dict[str, float],
+    *,
+    expression: str | None = None,
+    weights: Dict[str, float] | None = None,
+) -> float:
+    """Evaluate a composite objective based on ``metrics``.
 
+    Parameters
+    ----------
+    metrics:
+        Dictionary of metric values.
+    expression:
+        Optional Python expression combining metric names, e.g. ``"sharpe_ratio + 0.5*max_drawdown"``.
+        ``max_drawdown`` is typically negative, so adding it penalises the objective.
+    weights:
+        Alternatively, provide a mapping of metric weights.  The objective becomes
+        ``sum(weight * metric)``.
+
+    Returns
+    -------
+    float
+        The evaluated objective value.
+    """
+
+    if expression:
+        local = {k: float(v) for k, v in metrics.items()}
+        try:
+            return float(eval(expression, {"__builtins__": {}}, local))
+        except Exception:
+            return float("nan")
+    if weights:
+        return float(sum(metrics.get(k, 0.0) * w for k, w in weights.items()))
     return metrics.get("sharpe_ratio", 0.0)
 
 
 def passes_constraints(metrics: Dict[str, float], constraints: Constraints | None = None) -> bool:
     constraints = constraints or Constraints()
-    if metrics.get("trade_count", 0) < constraints.min_trades:
+    if constraints.min_trades is not None and metrics.get("trade_count", 0) < constraints.min_trades:
         return False
-    if abs(metrics.get("max_drawdown", 0)) > constraints.max_drawdown:
+    if (
+        constraints.max_drawdown is not None
+        and abs(metrics.get("max_drawdown", 0)) > constraints.max_drawdown
+    ):
+        return False
+    if (
+        constraints.max_volatility is not None
+        and metrics.get("volatility", 0.0) > constraints.max_volatility
+    ):
+        return False
+    if (
+        constraints.max_turnover is not None
+        and metrics.get("turnover", 0.0) > constraints.max_turnover
+    ):
         return False
     return True
+
+
+def rank_strategies(
+    strategies: Dict[str, Dict[str, float]] | Iterable[tuple[str, Dict[str, float]]],
+    *,
+    expression: str | None = None,
+    weights: Dict[str, float] | None = None,
+    constraints: Constraints | None = None,
+) -> pd.DataFrame:
+    """Rank ``strategies`` according to a composite objective.
+
+    Parameters
+    ----------
+    strategies:
+        Mapping or iterable of (name, metrics) pairs.
+    expression, weights:
+        Passed to :func:`objective`.
+    constraints:
+        Optional :class:`Constraints` limiting admissible strategies.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame sorted by objective value in descending order.  Contains the
+        objective and all metric values for each strategy that passes the
+        constraints.
+    """
+
+    if isinstance(strategies, dict):
+        items = strategies.items()
+    else:
+        items = strategies
+    rows = []
+    for name, mets in items:
+        if constraints and not passes_constraints(mets, constraints):
+            continue
+        obj = objective(mets, expression=expression, weights=weights)
+        row = {"strategy": name, "objective": obj}
+        row.update(mets)
+        rows.append(row)
+    df = pd.DataFrame(rows)
+    if df.empty:
+        return df
+    return df.sort_values("objective", ascending=False).reset_index(drop=True)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import pytest
+
+from sentimental_cap_predictor.evaluation import (
+    Constraints,
+    compute_metrics,
+    objective,
+    passes_constraints,
+    rank_strategies,
+)
+
+
+def test_compute_metrics_includes_new_metrics():
+    equity = pd.Series([1000, 1100, 1045, 1066], dtype=float)
+    trades = pd.DataFrame({"size": [10, -5], "entry_price": [100, 105]})
+    metrics = compute_metrics(equity, trades)
+    assert "sortino_ratio" in metrics
+    assert "volatility" in metrics
+    assert "turnover" in metrics
+    expected_turnover = (abs(10 * 100) + abs(-5 * 105)) / 1000
+    assert metrics["turnover"] == expected_turnover
+
+
+def test_objective_supports_expression():
+    metrics = {"sharpe_ratio": 1.0, "max_drawdown": -0.1}
+    value = objective(metrics, expression="sharpe_ratio + max_drawdown")
+    assert value == pytest.approx(0.9)
+
+
+def test_passes_constraints_configurable():
+    metrics = {"trade_count": 40, "max_drawdown": -0.1, "volatility": 0.15}
+    constraints = Constraints(max_drawdown=0.05)
+    assert not passes_constraints(metrics, constraints)
+    constraints = Constraints(max_drawdown=0.2, max_volatility=0.1)
+    assert not passes_constraints(metrics, constraints)
+    constraints = Constraints(max_drawdown=0.2, max_volatility=0.2)
+    assert passes_constraints(metrics, constraints)
+
+
+def test_rank_strategies_orders_by_objective():
+    strategies = {
+        "A": {"sharpe_ratio": 1.0, "max_drawdown": -0.1},
+        "B": {"sharpe_ratio": 0.5, "max_drawdown": -0.05},
+    }
+    ranked = rank_strategies(strategies, expression="sharpe_ratio + max_drawdown")
+    assert list(ranked["strategy"]) == ["A", "B"]


### PR DESCRIPTION
## Summary
- add Sortino ratio, volatility, and turnover metrics
- support composite objective expressions and flexible constraints
- include strategy ranking utility and corresponding tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a530d3ccdc832bb98f0d9210858930