### PR TITLE
Return DataFrame weights from strategies

### DIFF
--- a/src/sentimental_cap_predictor/strategy.py
+++ b/src/sentimental_cap_predictor/strategy.py
@@ -1,23 +1,40 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 import pandas as pd
 
 from .data_bundle import DataBundle
 
 
+@dataclass
+class StrategyParameters:
+    """Configuration parameters for a strategy."""
+
+    weight: float = 1.0
+
+
 class StrategyIdea(ABC):
     """Abstract base class for model-generated strategies."""
 
+    def __init__(self, params: StrategyParameters | None = None) -> None:
+        self.params = params or StrategyParameters()
+
     @abstractmethod
-    def generate_signals(self, data: DataBundle) -> pd.Series:
-        """Return target position signals indexed by date."""
+    def generate_signals(self, data: DataBundle) -> pd.DataFrame:
+        """Return target asset weights indexed by date."""
         raise NotImplementedError
 
 
 class BuyAndHoldStrategy(StrategyIdea):
     """Simple example strategy used as guidance for LLM-generated code."""
 
-    def generate_signals(self, data: DataBundle) -> pd.Series:  # pragma: no cover - trivial
-        return pd.Series(1, index=data.prices.index)
+    def generate_signals(self, data: DataBundle) -> pd.DataFrame:  # pragma: no cover - trivial
+        if isinstance(data.prices.columns, pd.MultiIndex):
+            assets = data.prices.columns.get_level_values(0).unique().tolist()
+        else:
+            assets = list(data.prices.columns)
+        return pd.DataFrame(
+            self.params.weight, index=data.prices.index, columns=assets
+        )

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from sentimental_cap_predictor.data_bundle import DataBundle
+from sentimental_cap_predictor.strategy import BuyAndHoldStrategy
+from sentimental_cap_predictor.backtester import backtest
+
+
+def test_buy_and_hold_generates_weight_dataframe():
+    index = pd.date_range("2024-01-01", periods=3, freq="D")
+    prices = pd.DataFrame({"AAPL": [1, 2, 3]}, index=index)
+    bundle = DataBundle(prices=prices).validate()
+
+    strategy = BuyAndHoldStrategy()
+    weights = strategy.generate_signals(bundle)
+
+    assert list(weights.columns) == ["AAPL"]
+    pd.testing.assert_frame_equal(weights, pd.DataFrame({"AAPL": [1.0, 1.0, 1.0]}, index=index))
+
+
+def test_backtester_interprets_weights():
+    index = pd.date_range("2024-01-01", periods=3, freq="D")
+    prices = pd.DataFrame({"AAPL": [1, 2, 3]}, index=index)
+    bundle = DataBundle(prices=prices).validate()
+
+    strategy = BuyAndHoldStrategy()
+    result = backtest(bundle, strategy, initial_capital=1_000.0)
+
+    assert result.equity_curve.iloc[-1] == 3_000.0


### PR DESCRIPTION
## Summary
- change strategies to emit `pd.DataFrame` of asset weights
- introduce typed `StrategyParameters` dataclass
- update backtester and add tests for weight-based signals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5338e2e18832bbc79041b1b60f206