### PR TITLE
Extend backtester for multi-asset next-bar execution

### DIFF
--- a/src/sentimental_cap_predictor/backtester.py
+++ b/src/sentimental_cap_predictor/backtester.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Mapping, Optional
 
 import pandas as pd
 
@@ -14,50 +14,122 @@ def backtest(
     data: DataBundle,
     strategy: StrategyIdea,
     initial_capital: float = 1_000_000.0,
-    cost_per_trade: float = 0.0,
-    slippage: float = 0.0,
+    cost_per_trade: float | Mapping[str, float] = 0.0,
+    slippage: float | Mapping[str, float] = 0.0,
 ) -> BacktestResult:
-    """Run a minimal backtest for ``strategy`` using ``data``.
+    """Run a minimal multi-asset backtest for ``strategy`` using ``data``.
 
-    Signals are interpreted as target weights for the first asset in
-    ``data.prices``.  Trades are executed at the same bar with optional fixed
-    transaction cost and proportional slippage.
+    Signals are interpreted as target weights for all assets contained in
+    ``data.prices``.  Orders derived from today's signals are executed on the
+    next bar, allowing both long and short positions.  Transaction costs and
+    slippage may be specified per asset via mappings.  Fill prices including
+    slippage are recorded in the trade log.
     """
 
-    prices = data.prices.iloc[:, 0]
-    weights = strategy.generate_signals(data).reindex(prices.index).fillna(0)
-    weight_series = weights.iloc[:, 0]
+    # ------------------------------------------------------------------
+    # Prepare price data and signals
+    # ------------------------------------------------------------------
+    if isinstance(data.prices.columns, pd.MultiIndex):
+        prices = data.prices.xs("close", level=-1, axis=1)
+    else:
+        prices = data.prices
 
-    position = 0.0
+    weights = strategy.generate_signals(data)
+    weights = weights.reindex(prices.index).reindex(columns=prices.columns, fill_value=0.0)
+    # Execute on next bar
+    weights = weights.shift(1).fillna(0.0)
+
+    assets = list(prices.columns)
+    get_cost = (lambda a: cost_per_trade.get(a, 0.0)) if isinstance(cost_per_trade, Mapping) else (lambda a: cost_per_trade)
+    get_slip = (lambda a: slippage.get(a, 0.0)) if isinstance(slippage, Mapping) else (lambda a: slippage)
+
+    positions = pd.Series(0.0, index=assets)
     cash = initial_capital
+
     equity_curve = []
     trades = []
-    trade_pnls = []
-    holding_periods = []
-    entry_price: Optional[float] = None
-    entry_date: Optional[pd.Timestamp] = None
+    trade_pnls: list[float] = []
+    holding_periods: list[int | float] = []
+    entry_price: dict[str, Optional[float]] = {a: None for a in assets}
+    entry_date: dict[str, Optional[pd.Timestamp]] = {a: None for a in assets}
 
-    for date, price in prices.items():
-        desired_weight = weight_series.loc[date]
-        equity = cash + position * price
-        desired = desired_weight * equity / price
-        if desired != position:
-            trade_size = desired - position
-            trade_price = price * (1 + slippage if trade_size > 0 else 1 - slippage)
-            cash -= trade_size * trade_price
-            cash -= cost_per_trade
+    for date, price_row in prices.iterrows():
+        equity = cash + float((positions * price_row).sum())
+        desired_positions = weights.loc[date] * equity / price_row
 
-            if position != 0:
-                pnl = (trade_price - entry_price) * position  # type: ignore
+        for asset in assets:
+            price = price_row[asset]
+            current = positions[asset]
+            desired = desired_positions[asset]
+
+            if desired == current:
+                continue
+
+            cost = get_cost(asset)
+            slip = get_slip(asset)
+
+            # Handle position flip as close followed by open
+            if current != 0 and desired != 0 and current * desired < 0:
+                # Close existing
+                trade_size = -current
+                trade_price = price * (1 + slip if trade_size > 0 else 1 - slip)
+                cash -= trade_size * trade_price
+                cash -= cost
+
+                pnl = (trade_price - entry_price[asset]) * current  # type: ignore[arg-type]
                 trade_pnls.append(pnl)
-                holding = (date - entry_date).days if isinstance(date, pd.Timestamp) else date - entry_date  # type: ignore
+                holding = (
+                    (date - entry_date[asset]).days
+                    if isinstance(date, pd.Timestamp)
+                    else date - entry_date[asset]
+                )  # type: ignore[arg-type]
                 holding_periods.append(holding)
                 trades.append(
                     {
-                        "entry_date": entry_date,
+                        "asset": asset,
+                        "entry_date": entry_date[asset],
                         "exit_date": date,
-                        "size": position,
-                        "entry_price": entry_price,
+                        "size": current,
+                        "entry_price": entry_price[asset],
+                        "exit_price": trade_price,
+                        "pnl": pnl,
+                        "holding_period": holding,
+                    }
+                )
+
+                # Open new position
+                trade_size = desired
+                trade_price = price * (1 + slip if trade_size > 0 else 1 - slip)
+                cash -= trade_size * trade_price
+                cash -= cost
+
+                entry_price[asset] = trade_price
+                entry_date[asset] = date
+                positions[asset] = desired
+                continue
+
+            # Simple change in position (including open or close)
+            trade_size = desired - current
+            trade_price = price * (1 + slip if trade_size > 0 else 1 - slip)
+            cash -= trade_size * trade_price
+            cash -= cost
+
+            if current != 0:
+                pnl = (trade_price - entry_price[asset]) * current  # type: ignore[arg-type]
+                trade_pnls.append(pnl)
+                holding = (
+                    (date - entry_date[asset]).days
+                    if isinstance(date, pd.Timestamp)
+                    else date - entry_date[asset]
+                )  # type: ignore[arg-type]
+                holding_periods.append(holding)
+                trades.append(
+                    {
+                        "asset": asset,
+                        "entry_date": entry_date[asset],
+                        "exit_date": date,
+                        "size": current,
+                        "entry_price": entry_price[asset],
                         "exit_price": trade_price,
                         "pnl": pnl,
                         "holding_period": holding,
@@ -65,15 +137,15 @@ def backtest(
                 )
 
             if desired != 0:
-                entry_price = trade_price
-                entry_date = date
+                entry_price[asset] = trade_price
+                entry_date[asset] = date
             else:
-                entry_price = None
-                entry_date = None
+                entry_price[asset] = None
+                entry_date[asset] = None
 
-            position = desired
+            positions[asset] = desired
 
-        equity_curve.append({"date": date, "equity": cash + position * price})
+        equity_curve.append({"date": date, "equity": cash + float((positions * price_row).sum())})
 
     equity_series = pd.Series([e["equity"] for e in equity_curve], index=prices.index)
     trades_df = pd.DataFrame(trades)

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,0 +1,56 @@
+import pandas as pd
+import pytest
+
+from sentimental_cap_predictor.backtester import backtest
+from sentimental_cap_predictor.data_bundle import DataBundle
+from sentimental_cap_predictor.strategy import StrategyIdea
+
+
+class DummyStrategy(StrategyIdea):
+    """Strategy returning pre-defined weights used for testing."""
+
+    def __init__(self, weight_df: pd.DataFrame):
+        super().__init__(None)
+        self._weights = weight_df
+
+    def generate_signals(self, data: DataBundle) -> pd.DataFrame:
+        return self._weights
+
+
+def test_multi_asset_next_bar_and_costs():
+    index = pd.date_range("2024-01-01", periods=3, freq="D")
+    prices = pd.DataFrame(
+        {
+            ("AAPL", "close"): [10, 11, 12],
+            ("MSFT", "close"): [20, 19, 18],
+        },
+        index=index,
+    )
+    bundle = DataBundle(prices=prices)
+
+    weights = pd.DataFrame(
+        [[1, -1], [0, 0], [0, 0]], index=index, columns=["AAPL", "MSFT"]
+    )
+    strat = DummyStrategy(weights)
+
+    result = backtest(
+        bundle,
+        strat,
+        initial_capital=1_000.0,
+        cost_per_trade={"AAPL": 1.0, "MSFT": 2.0},
+        slippage={"AAPL": 0.01, "MSFT": 0.02},
+    )
+
+    trades = result.trades
+    assert set(trades["asset"]) == {"AAPL", "MSFT"}
+    # Signals executed on next bar
+    assert (trades["entry_date"] == index[1]).all()
+    # Short positions allowed
+    assert trades[trades["asset"] == "MSFT"]["size"].iloc[0] < 0
+    # Fill prices include slippage
+    aapl_trade = trades[trades["asset"] == "AAPL"].iloc[0]
+    assert aapl_trade["entry_price"] == pytest.approx(11 * 1.01)
+    assert aapl_trade["exit_price"] == pytest.approx(12 * 0.99)
+    # Portfolio equity after closing positions
+    assert result.equity_curve.iloc[-1] == pytest.approx(1077.6842105263)
+

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -25,4 +25,6 @@ def test_backtester_interprets_weights():
     strategy = BuyAndHoldStrategy()
     result = backtest(bundle, strategy, initial_capital=1_000.0)
 
-    assert result.equity_curve.iloc[-1] == 3_000.0
+    # With next-bar execution the long position is entered at price 2 and
+    # remains open at the end of the sample.
+    assert result.equity_curve.iloc[-1] == 1_500.0


### PR DESCRIPTION
## Summary
- Support multi-asset portfolios with next-bar order execution
- Allow per-asset transaction costs, slippage and short selling
- Add regression test covering multi-asset handling and fill prices

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a534879008832b9ce346a5205d6215