### PR TITLE
Refactor research modules to use unified DataBundle

### DIFF
--- a/research/sandbox.py
+++ b/research/sandbox.py
@@ -11,10 +11,10 @@ import pickle
 import subprocess
 import textwrap
 
+from sentimental_cap_predictor.data_bundle import DataBundle
 from sentimental_cap_predictor.research.types import (
     BacktestContext,
     BacktestResult,
-    DataBundle,
     Idea,
 )
 

--- a/src/sentimental_cap_predictor/data/loader.py
+++ b/src/sentimental_cap_predictor/data/loader.py
@@ -1,10 +1,11 @@
-from __future__ import annotations
 """Utilities for loading market, sentiment and fundamental data."""
+
+from __future__ import annotations
 
 import pandas as pd
 import yfinance as yf
 
-from ..research.types import DataBundle
+from sentimental_cap_predictor.data_bundle import DataBundle
 
 
 def load_prices(ticker: str, start: str | pd.Timestamp, end: str | pd.Timestamp) -> pd.DataFrame:
@@ -95,5 +96,10 @@ def make_bundle(ticker: str, start: str | pd.Timestamp, end: str | pd.Timestamp)
     sentiment = align_daily(sentiment, prices.index)
     fundamentals = align_pit_fundamentals(fundamentals_raw, prices.index)
     meta = {"ticker": ticker, "start": str(start), "end": str(end)}
-    return DataBundle(prices=prices, sentiment=sentiment, fundamentals=fundamentals, meta=meta)
+    return DataBundle(
+        prices=prices,
+        features=fundamentals,
+        sentiment=sentiment,
+        metadata=meta,
+    ).validate()
 

--- a/src/sentimental_cap_predictor/research/engine.py
+++ b/src/sentimental_cap_predictor/research/engine.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Lightweight backtesting utilities for research workflows.
 
 This module exposes a convenience function :func:`simple_backtester` that
@@ -16,20 +14,17 @@ simple basis-point specification.  Common performance metrics are reported in a
 ``Strategy`` protocol combining price momentum with optional sentiment filters.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Callable, List, Dict
 
 import numpy as np
 import pandas as pd
 
+from sentimental_cap_predictor.data_bundle import DataBundle
 from .idea_schema import Idea
-from .types import (
-    BacktestContext,
-    BacktestResult,
-    DataBundle,
-    Strategy,
-    Trade,
-)
+from .types import BacktestContext, BacktestResult, Strategy, Trade
 
 
 @dataclass
@@ -88,7 +83,7 @@ def simple_backtester(strategy: Strategy) -> Callable[[DataBundle, Idea, Backtes
         equity_curve = (1.0 + strategy_returns).cumprod()
 
         trade_list: List[Trade] = []
-        symbol = data.meta.get("ticker", "")
+        symbol = (data.metadata or {}).get("ticker", "")
         for ts, change in pos_diff[pos_diff != 0].items():
             side = "buy" if change > 0 else "sell"
             fees = float(abs(change) * cost_per_trade)

--- a/src/sentimental_cap_predictor/research/types.py
+++ b/src/sentimental_cap_predictor/research/types.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Core type definitions used across research workflows.
 
 This module centralises small data containers and protocols that are shared
@@ -8,37 +6,15 @@ structures provide a consistent interface for handling market and sentiment
 inputs, passing configuration to backtests and capturing their results.
 """
 
-from dataclasses import dataclass, field
+from __future__ import annotations
+
+from dataclasses import dataclass
 from typing import Any, Dict, List, Protocol
 
 import pandas as pd
 
+from sentimental_cap_predictor.data_bundle import DataBundle
 from .idea_schema import Idea
-
-
-@dataclass
-class DataBundle:
-    """Collection of market, sentiment and fundamental data.
-
-    Attributes
-    ----------
-    prices:
-        ``pandas.DataFrame`` of price data indexed by datetime.
-    sentiment:
-        Optional ``pandas.DataFrame`` containing sentiment features aligned with
-        ``prices``.
-    fundamentals:
-        Optional ``pandas.DataFrame`` of point-in-time fundamental data aligned
-        to ``prices``.
-    meta:
-        Arbitrary metadata describing the data set such as ticker, source or
-        preprocessing information.
-    """
-
-    prices: pd.DataFrame
-    sentiment: pd.DataFrame | None = None
-    fundamentals: pd.DataFrame | None = None
-    meta: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/research/test_data_bundle_validation.py
+++ b/tests/research/test_data_bundle_validation.py
@@ -1,0 +1,12 @@
+import pandas as pd
+import pytest
+
+from sentimental_cap_predictor.data_bundle import DataBundle
+
+
+def test_research_bundle_validate_rejects_misalignment():
+    idx = pd.date_range('2020-01-01', periods=2, freq='D')
+    prices = pd.DataFrame({'close': [1, 2]}, index=idx)
+    bad_sent = pd.DataFrame({'score': [0.1, 0.2]}, index=idx[::-1])
+    with pytest.raises(ValueError):
+        DataBundle(prices=prices, sentiment=bad_sent).validate()

--- a/tests/research/test_engine_accounting.py
+++ b/tests/research/test_engine_accounting.py
@@ -1,9 +1,10 @@
 import pandas as pd
 import pytest
 
+from sentimental_cap_predictor.data_bundle import DataBundle
 from sentimental_cap_predictor.research.engine import simple_backtester
-from sentimental_cap_predictor.research.types import BacktestContext, DataBundle
 from sentimental_cap_predictor.research.idea_schema import Idea
+from sentimental_cap_predictor.research.types import BacktestContext
 
 
 class AlwaysLong:
@@ -14,7 +15,7 @@ class AlwaysLong:
 def test_constant_weight_pnl_and_cost_impact():
     index = pd.date_range('2020-01-01', periods=3, freq='D')
     prices = pd.DataFrame({'open': [100, 100, 100], 'close': [101, 101, 101]}, index=index)
-    data = DataBundle(prices=prices)
+    data = DataBundle(prices=prices).validate()
     idea = Idea(name='long')
     ctx = BacktestContext(fees_bps=1, slip_bps=2)
 

--- a/tests/research/test_sandbox.py
+++ b/tests/research/test_sandbox.py
@@ -1,15 +1,15 @@
 import pandas as pd
 import pytest
 
+from sentimental_cap_predictor.data_bundle import DataBundle
 from research.sandbox import SandboxError, run_strategy_source
 from sentimental_cap_predictor.research.idea_schema import Idea
-from sentimental_cap_predictor.research.types import DataBundle
 
 
 def test_forbidden_import_raises_sandbox_error():
     index = pd.date_range('2020-01-01', periods=1, freq='D')
     prices = pd.DataFrame({'close': [1.0]}, index=index)
-    data = DataBundle(prices=prices)
+    data = DataBundle(prices=prices).validate()
     idea = Idea(name='x')
     source = "import os\nstrategy = None"
     with pytest.raises(SandboxError):

--- a/tests/research/test_strategy_contract.py
+++ b/tests/research/test_strategy_contract.py
@@ -3,16 +3,16 @@ import re
 
 import pandas as pd
 
+from sentimental_cap_predictor.data_bundle import DataBundle
 from sentimental_cap_predictor.research.engine import SmaSentStrategy
 from sentimental_cap_predictor.research.idea_schema import Idea
-from sentimental_cap_predictor.research.types import DataBundle
 
 
 def test_signal_alignment_and_bounds_and_no_shift():
     index = pd.date_range('2020-01-01', periods=5, freq='D')
     prices = pd.DataFrame({'close': range(1, 6)}, index=index)
     sentiment = pd.DataFrame({'score': [0, 1, 0.5, 1, 0]}, index=index)
-    data = DataBundle(prices=prices, sentiment=sentiment)
+    data = DataBundle(prices=prices, sentiment=sentiment).validate()
     idea = Idea(name='sma', params={'ma_window': 2, 'sent_thr': 0.3})
     strat = SmaSentStrategy()
 

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -26,7 +26,7 @@ def test_multi_asset_next_bar_and_costs():
         },
         index=index,
     )
-    bundle = DataBundle(prices=prices)
+    bundle = DataBundle(prices=prices).validate()
 
     weights = pd.DataFrame(
         [[1, -1], [0, 0], [0, 0]], index=index, columns=["AAPL", "MSFT"]
@@ -58,7 +58,7 @@ def test_multi_asset_next_bar_and_costs():
 def test_backtest_generates_metrics_and_trades():
     index = pd.date_range('2024-01-01', periods=3, freq='D')
     prices = pd.DataFrame({('AAPL', 'close'): [10, 11, 12]}, index=index)
-    bundle = DataBundle(prices=prices)
+    bundle = DataBundle(prices=prices).validate()
 
     weights = pd.DataFrame([1.0, 0.0, 0.0], index=index, columns=['AAPL'])
     strat = DummyStrategy(weights)


### PR DESCRIPTION
## Summary
- reuse core `DataBundle` from `sentimental_cap_predictor.data_bundle`
- adapt research utilities and CLI to new bundle structure
- add regression tests for `DataBundle.validate` in research workflows

## Testing
- `ruff check src/sentimental_cap_predictor/research/types.py src/sentimental_cap_predictor/research/engine.py src/sentimental_cap_predictor/data/loader.py bin/run_research.py research/sandbox.py tests/research/test_engine_accounting.py tests/research/test_sandbox.py tests/research/test_strategy_contract.py tests/test_backtester.py tests/research/test_data_bundle_validation.py`
- `pytest` *(failed: TimeoutError in tests/test_sandbox.py::test_dangerous_builtin_not_available, tests/test_sandbox.py::test_memory_limit, tests/test_sandbox.py::test_run_code_returns_environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e0665088832ba0eebdaeb2b00949