### PR TITLE
Add optional resampling to DataBundle

### DIFF
--- a/docs/data_bundle.md
+++ b/docs/data_bundle.md
@@ -2,7 +2,11 @@
 
 A `DataBundle` groups time-aligned market and alternative data used by the
 library.  All contained :class:`pandas.DataFrame` instances must share the same
-`DatetimeIndex`.
+`DatetimeIndex`.  If some frames are sampled at a lower frequency (e.g., weekly
+sentiment scores combined with daily prices) the
+:py:meth:`~sentimental_cap_predictor.data_bundle.DataBundle.validate` method can
+optionally resample or forward‑fill these data to the price index by passing
+``resample_method="ffill"`` or ``"resample"``.
 
 For **multi‑asset** bundles the columns should use a two‑level
 :class:`pandas.MultiIndex` with the first level being the asset identifier and


### PR DESCRIPTION
## Summary
- allow DataBundle.validate to resample or forward-fill misaligned frames
- document resampling option and its usage
- test daily prices with weekly sentiment aligned without lookahead

## Testing
- `pytest` (fails: tests/test_sandbox.py::test_dangerous_builtin_not_available - TimeoutError; tests/test_sandbox.py::test_memory_limit - TimeoutError; tests/test_sandbox.py::test_run_code_returns_environment - TimeoutError)
- `pytest tests/test_data_bundle.py::test_weekly_sentiment_resampled_to_daily_prices_without_lookahead -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f71a02b8832b80d2dc1524871615