### PR TITLE
feat: track parameters alongside metrics

### DIFF
--- a/docs/research.md
+++ b/docs/research.md
@@ -13,3 +13,18 @@ def backtest(idea: Idea):
 idea = Idea(name="My idea", params={"window": 5})
 result = apply_idea(idea, backtest)
 ```
+
+## Experiment Tracking
+
+The `LocalTracker` offers lightweight experiment logging without requiring an
+external service. Parameters can be recorded alongside metrics and later joined
+for analysis.
+
+```python
+from research.tracking import LocalTracker
+
+tracker = LocalTracker(root="./runs")
+tracker.start_run({"window": 5})
+tracker.log_metrics({"accuracy": 0.9})
+tracker.end_run()
+```

--- a/tests/test_local_tracker.py
+++ b/tests/test_local_tracker.py
@@ -1,0 +1,20 @@
+from research.tracking import LocalTracker, Metric, Param
+
+
+def test_params_and_metrics_queryable(tmp_path):
+    tracker = LocalTracker(root=tmp_path)
+    run_id = tracker.start_run({"lr": 0.1})
+    tracker.log_metrics({"loss": 0.5})
+
+    with tracker.SessionLocal() as session:
+        rows = (
+            session.query(Metric, Param)
+            .join(Param, Metric.run_id == Param.run_id)
+            .filter(Metric.run_id == run_id)
+            .all()
+        )
+
+    assert len(rows) == 1
+    metric, param = rows[0]
+    assert metric.key == "loss" and metric.value == 0.5
+    assert param.key == "lr" and param.value == "0.1"


### PR DESCRIPTION
## Summary
- record run parameters in a dedicated `params` table
- allow `start_run` to accept parameters and save them
- document local experiment tracking and add test covering parameter queries

## Testing
- `pre-commit run --files research/tracking.py docs/research.md tests/test_local_tracker.py`
- `pytest tests/test_local_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5fc86cc20832bb7a7244f9a8e9b2e