### PR TITLE
Add operation limit to research sandbox

### DIFF
--- a/tests/research/test_sandbox.py
+++ b/tests/research/test_sandbox.py
@@ -1,17 +1,32 @@
 import pandas as pd
 import pytest
 
-from sentimental_cap_predictor.data_bundle import DataBundle
 from research.sandbox import SandboxError, run_strategy_source
+from sentimental_cap_predictor.data_bundle import DataBundle
 from sentimental_cap_predictor.research.idea_schema import Idea
 
 
 def test_forbidden_import_raises_sandbox_error():
-    index = pd.date_range('2020-01-01', periods=1, freq='D')
-    prices = pd.DataFrame({'close': [1.0]}, index=index)
+    index = pd.date_range("2020-01-01", periods=1, freq="D")
+    prices = pd.DataFrame({"close": [1.0]}, index=index)
     data = DataBundle(prices=prices).validate()
-    idea = Idea(name='x')
+    idea = Idea(name="x")
     source = "import os\nstrategy = None"
     with pytest.raises(SandboxError):
         run_strategy_source(source, data, idea)
 
+
+def test_infinite_loop_terminates():
+    index = pd.date_range("2020-01-01", periods=1, freq="D")
+    prices = pd.DataFrame({"close": [1.0]}, index=index)
+    data = DataBundle(prices=prices).validate()
+    idea = Idea(name="x")
+    source = "\n".join(
+        [
+            "def strategy(data, idea, ctx):",
+            "    while True:",
+            "        pass",
+        ]
+    )
+    with pytest.raises(SandboxError):
+        run_strategy_source(source, data, idea, max_ops=1000)


### PR DESCRIPTION
## Summary
- limit sandboxed strategy execution by counting traced line events
- expose configurable `max_ops` parameter to cap operations
- add test ensuring infinite loops terminate with SandboxError

## Testing
- `pre-commit run --files research/sandbox.py tests/research/test_sandbox.py` *(fails: isort and ruff-format conflict)*
- `pytest tests/research/test_sandbox.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5fc7e1a5c832ba0634700e42a237d