### PR TITLE
Compute trade PnL and holding periods

### DIFF
--- a/tests/test_research_backtester.py
+++ b/tests/test_research_backtester.py
@@ -51,3 +51,11 @@ def test_simple_backtester_trades_and_equity():
         result.trades.reset_index(drop=True),
         expected_trades,
     )
+    expected_pnls = pd.Series([0.0, 1.0])
+    expected_holding = pd.Series([0.0, 1.0])
+    pd.testing.assert_series_equal(
+        result.trade_pnls.reset_index(drop=True), expected_pnls
+    )
+    pd.testing.assert_series_equal(
+        result.holding_periods.reset_index(drop=True), expected_holding
+    )


### PR DESCRIPTION
## Summary
- compute per-trade P&L and holding period during trade log generation
- expose trade PnLs and holding durations via `BacktestResult`
- test trade PnL and holding period output in simple backtester

## Testing
- `pytest`
- `pytest tests/test_research_backtester.py tests/research/test_engine_accounting.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6041daa6c832bb510c7c85d1523f8