### PR TITLE
docs: add testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,23 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
 
 Run `--help` with any module for detailed options.
+
+## Testing
+
+1. **Install development dependencies**
+   ```bash
+   pip install -e .[dev]
+   ```
+2. **Run linters and formatters**
+   ```bash
+   pre-commit run --all-files
+   ```
+3. **Execute tests**
+   ```bash
+   pytest
+   ```
+   `make test` is also supported.
+
+Environment variables such as `TEST_TICKER` (to choose a ticker for integration
+tests) and `OFFLINE_TEST` (to disable external data fetching) may be required for
+certain test scenarios.


### PR DESCRIPTION
## Summary
- document development and test workflow in README, including linting and environment variables

## Testing
- `pre-commit run --files README.md`
- `pytest` *(fails: TimeoutError in tests/test_sandbox.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a607c276d4832ba9a69134beed36d0