### PR TITLE
fix dataset import

### DIFF
--- a/src/sentimental_cap_predictor/dataset.py
+++ b/src/sentimental_cap_predictor/dataset.py
@@ -16,7 +16,7 @@ from .data_bundle import DataBundle
 
 load_dotenv()
 
-from config import RAW_DATA_DIR
+from .config import RAW_DATA_DIR
 
 # Initialize colorama
 init(autoreset=True)


### PR DESCRIPTION
## Summary
- use package-relative config import in dataset module

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/dataset.py` (fails: E402 Module level import not at top of file)
- `PYTHONPATH=src python -m sentimental_cap_predictor.dataset --help`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a663ecc43c832b832e32f3e11f9125