### PR TITLE
feat: configure user agent for article extraction

### DIFF
--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,6 +1,8 @@
 import pandas as pd
 
 from sentimental_cap_predictor.data.news import FileSource, fetch_news
+from sentimental_cap_predictor import dataset
+import pytest
 
 
 def test_fetch_news_returns_columns():
@@ -24,3 +26,27 @@ def test_file_source_reads_csv(tmp_path):
     assert len(df) == 1
     assert df.iloc[0]["headline"] == "Example"
     assert list(df.columns) == ["date", "headline", "source"]
+
+
+@pytest.mark.parametrize("use_headless, expected", [(True, "HeadlessChrome"), (False, "Chrome/58")])
+def test_extract_article_content_user_agent(monkeypatch, use_headless, expected):
+    captured = {}
+
+    class DummyArticle:
+        def __init__(self, url, config, keep_article_html=True):
+            captured["ua"] = config.browser_user_agent
+            captured["timeout"] = config.request_timeout
+            self.text = "body"
+
+        def download(self):
+            pass
+
+        def parse(self):
+            pass
+
+    monkeypatch.setattr(dataset, "Article", DummyArticle)
+
+    text = dataset.extract_article_content("http://example.com", use_headless=use_headless)
+    assert text == "body"
+    assert expected in captured["ua"]
+    assert captured["timeout"] == 10


### PR DESCRIPTION
## Summary
- configure newspaper3k `Article` via `Config` to support a headless user agent and request timeout
- exercise user agent logic in a new `extract_article_content` test

## Testing
- `pytest tests/test_news.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6660a6128832bbb57b6e92cf34d59