### PR TITLE
Refactor sentiment aggregation and add tests

### DIFF
--- a/src/sentimental_cap_predictor/modeling/sentiment_analysis.py
+++ b/src/sentimental_cap_predictor/modeling/sentiment_analysis.py
@@ -150,21 +150,15 @@ def aggregate_sentiment_by_date(analyzed_df: pd.DataFrame) -> pd.DataFrame:
     # Group by date and calculate the weighted mean sentiment
     # and mean confidence
     aggregated_df = (
-        analyzed_df.groupby("date")
-        .apply(
-            lambda x: pd.Series(
-                {
-                    "bias_factor": (
-                        x["weighted_confidence"].sum() / x["confidence"].sum()
-                        if x["confidence"].sum() != 0
-                        else 0
-                    ),
-                    "mean_confidence": x["confidence"].mean(),
-                }
-            )
+        analyzed_df.groupby("date").agg(
+            bias_factor=(
+                "weighted_confidence",
+                lambda x: x.sum()
+                / analyzed_df.loc[x.index, "confidence"].sum(),
+            ),
+            mean_confidence=("confidence", "mean"),
         )
-        .reset_index()
-    )
+    ).reset_index()
 
     # Determine the final sentiment label based on the bias factor
     aggregated_df["final_sentiment"] = aggregated_df["bias_factor"].apply(

--- a/tests/test_sentiment_aggregation.py
+++ b/tests/test_sentiment_aggregation.py
@@ -1,0 +1,55 @@
+import importlib
+import sys
+import types
+
+import pandas as pd
+import pytest
+
+
+def test_aggregate_sentiment_by_date_calculates_bias_and_confidence(monkeypatch):
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+        def encode(self, content, truncation=True, max_length=512):
+            return []
+
+        def decode(self, tokens, skip_special_tokens=True):
+            return ""
+
+    dummy_transformers = types.SimpleNamespace(
+        DistilBertTokenizer=DummyTokenizer,
+        pipeline=lambda *args, **kwargs: None,
+    )
+
+    sys.modules["transformers"] = dummy_transformers
+    sys.modules.pop(
+        "sentimental_cap_predictor.modeling.sentiment_analysis", None
+    )
+    sentiment_analysis = importlib.import_module(
+        "sentimental_cap_predictor.modeling.sentiment_analysis"
+    )
+
+    df = pd.DataFrame(
+        {
+            "date": pd.to_datetime([
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-02",
+            ]),
+            "weighted_sentiment": [0.5, -0.2, 0.3],
+            "confidence": [0.8, 0.2, 0.4],
+        }
+    )
+
+    aggregated = sentiment_analysis.aggregate_sentiment_by_date(df)
+
+    day1 = aggregated.loc[aggregated["date"] == pd.Timestamp("2024-01-01")].iloc[0]
+    day2 = aggregated.loc[aggregated["date"] == pd.Timestamp("2024-01-02")].iloc[0]
+
+    assert day1["bias_factor"] == pytest.approx(0.36)
+    assert day1["mean_confidence"] == pytest.approx(0.5)
+    assert day2["bias_factor"] == pytest.approx(0.3)
+    assert day2["mean_confidence"] == pytest.approx(0.4)
+    assert set(aggregated["final_sentiment"]) == {"POSITIVE"}


### PR DESCRIPTION
## Summary
- refactor sentiment aggregation to compute bias and confidence with groupby.agg
- add dedicated test for daily sentiment aggregation

## Testing
- `pytest tests/test_sentiment_aggregation.py tests/test_model_training.py -q > /tmp/pytest.log && cat /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68a66d436a3c832b97d8bab3ed55256d