### PR TITLE
Add user manual and documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Each module exposes a Typer application:
 
 Run `--help` with any module for detailed options.
 
+## Documentation
+
+See the [User Manual](docs/user_manual.md) for environment setup, workflow
+descriptions, and testing guidance.
+
 ## Offline Testing
 
 Some tests require downloading market data. To run them without making

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# Documentation Index
+
+- [User Manual](user_manual.md)
+- [Command Line Interface](cli.md)
+- [Data Bundle Format](data_bundle.md)
+- [Scheduling](scheduling.md)
+- [Research Hooks](research.md)

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1,0 +1,54 @@
+# CAP Predictor User Manual
+
+## Environment Setup
+- Copy the sample environment file and fill in API keys or paths:
+  ```bash
+  cp .env.example .env
+  ```
+- Install dependencies in editable mode with development extras:
+  ```bash
+  pip install -e .[dev]
+  ```
+
+## Data Ingestion and Sentiment Analysis
+- Download price and news data for a ticker:
+  ```bash
+  python -m sentimental_cap_predictor.dataset TICKER --period 1Y
+  ```
+- Generate plots or other visualizations:
+  ```bash
+  python -m sentimental_cap_predictor.plots TICKER
+  ```
+- Run the sentiment analysis module on collected news:
+  ```bash
+  python -m sentimental_cap_predictor.modeling.sentiment_analysis <NEWS_PATH>
+  ```
+
+## Model Training, Evaluation, and Daily Pipeline
+- Train baseline models and write evaluation metrics:
+  ```bash
+  python -m sentimental_cap_predictor.modeling.train_eval TICKER
+  ```
+- Visualize results or build trading strategies using the provided utilities.
+- Execute the end‑to‑end daily workflow:
+  ```bash
+  python -m sentimental_cap_predictor.flows.daily_pipeline run TICKER
+  ```
+  This pipeline downloads data, trains the model, searches for a strategy, and produces a summary report.
+
+## Testing Guidance
+- Run the test suite with `pytest`:
+  ```bash
+  pytest
+  ```
+- To avoid network calls, enable offline mode:
+  ```bash
+  OFFLINE_TEST=1 TEST_TICKER=AAPL pytest
+  ```
+  The `OFFLINE_TEST` flag makes tests use cached CSVs under `tests/data`.
+
+## Additional Resources
+- [Command Line Interface](cli.md)
+- [Data Bundle Format](data_bundle.md)
+- [Scheduling](scheduling.md)
+- [Research Hooks](research.md)


### PR DESCRIPTION
## Summary
- Create comprehensive user manual covering setup, workflows, testing guidance, and links to topic docs
- Introduce documentation index for easier navigation
- Reference user manual from README

## Testing
- `OFFLINE_TEST=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy', 'colorama', 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68a73defe88c832bbe82b6c99adc6ce7