### PR TITLE
docs: cross-link user manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Run `--help` with any module for detailed options.
 ## Documentation
 
 See the [User Manual](docs/user_manual.md) for environment setup, workflow
-descriptions, and testing guidance.
+descriptions, and testing guidance. For topic-specific guides, browse the
+[Documentation Index](docs/index.md).
 
 ## Offline Testing
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,3 +72,8 @@ Use cron to execute the pipeline every weekday at 6am:
 
 Make sure the virtual environment is activated or provide the full path to the
 Python interpreter in the cron entry.
+
+## Additional Resources
+
+- [User Manual](user_manual.md) – step-by-step setup and workflows
+- [Documentation Index](index.md) – links to all project guides

--- a/docs/data_bundle.md
+++ b/docs/data_bundle.md
@@ -23,3 +23,8 @@ index               AAPL                  MSFT
 Single‑asset bundles may keep a flat column index with only field names.  Any
 optional publication timestamps must mirror the shape of the corresponding data
 frames and must not be later than the data's timestamp.
+
+## Additional Resources
+
+- [User Manual](user_manual.md) – project setup and workflows
+- [Documentation Index](index.md) – overview of all documentation

--- a/docs/research.md
+++ b/docs/research.md
@@ -28,3 +28,8 @@ tracker.start_run({"window": 5})
 tracker.log_metrics({"accuracy": 0.9})
 tracker.end_run()
 ```
+
+## Additional Resources
+
+- [User Manual](user_manual.md) – end-to-end usage guide
+- [Documentation Index](index.md) – list of all documentation topics

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -40,3 +40,8 @@ schtasks /Create /SC DAILY /ST 02:00 /TN "Cap Predictor Nightly" ^
 The task will run the pipeline nightly and append output to
 `logs\nightly.log`. Adjust the start time, ticker symbol, or environment
 variables as needed for your setup.
+
+## Additional Resources
+
+- [User Manual](user_manual.md) – complete usage guide
+- [Documentation Index](index.md) – overview of all docs


### PR DESCRIPTION
## Summary
- cross-link README to full documentation index
- add "Additional Resources" sections linking to user manual and index across existing docs

## Testing
- `OFFLINE_TEST=1 pytest` *(fails: Missing raw price parquet at data/raw/AAPL_prices.parquet)*

------
https://chatgpt.com/codex/tasks/task_e_68a73ae25b50832bbc3db30299b7661c