### PR TITLE
Add FastAPI UI skeleton with chat and monitoring endpoints

### DIFF
--- a/docs/ui_proposal.md
+++ b/docs/ui_proposal.md
@@ -1,0 +1,46 @@
+# CAP Predictor UI Proposal
+
+This document outlines a user-accessible UI for the CAP Predictor platform. It incorporates a persistent chatbot assistant, monitoring dashboards, asset-level performance views, decision-traceability, and accessibility considerations. It also sketches integration points with Mistral data sourcing and DeepSeek implementations.
+
+## 1. Persistent Chatbot Assistant
+- Docked chat panel that remains visible across screens, powered by an LLM.
+- Provides context-aware explanations of models, outputs, and code snippets.
+- Supports exporting conversation history for audits and collaboration.
+- Optional session-level memory so it can tailor responses to user actions.
+
+## 2. Visual Monitoring Dashboards
+- **Main Model Dashboard**: real-time metrics (accuracy, latency), historical trends, and deployment status.
+- **Experimental Model Dashboard**: compare experimental models against the main model with feature importance charts and hyperparameter summaries.
+- Uses WebSockets for live updates and allows promoting an experimental model when it outperforms the baseline.
+
+## 3. Asset-Level Performance Views
+- Drill-down interface to inspect predictions vs. actuals for individual assets.
+- Filters by asset type, region, or time frame and supports CSV/JSON export.
+- Scatter plots and sortable tables facilitate quick investigation of outliers.
+
+## 4. Decision Logic Traceability
+- "Explain this prediction" button opens a trace explorer showing feature values and model contributions.
+- Each interaction is logged with timestamps and user IDs, supporting audits and version diffing.
+
+## 5. Accessibility Design
+- **Professional Mode**: dense tables, advanced filters, and code snippets.
+- **Beginner Mode**: simplified visuals with guided tooltips and walkthroughs.
+- WCAG-compliant colors, keyboard navigation, ARIA roles, adjustable fonts, and dark/light themes.
+
+## 6. Integration with Mistral and DeepSeek
+- **Mistral Data Sourcing**: dashboard panel shows dataset provenance, update schedules, and quality metrics derived from Mistral pipelines. Chatbot can reference data lineage when answering questions.
+- **DeepSeek Implementations**: experimental models deployed on DeepSeek infrastructure with metrics surfaced in dashboards. Decision traces link to DeepSeek-hosted model configs.
+
+## 7. Technology Stack
+- Frontend: React + TypeScript using a component library and Plotly/D3 for charts.
+- Backend: FastAPI routes backed by PostgreSQL and Redis; WebSockets for live metrics.
+- Chatbot: Mistral or DeepSeek LLM APIs with a context manager for conversation state.
+- Deployment: Dockerized services orchestrated with Kubernetes for scalability and resilience.
+
+## 8. Next Steps
+1. Create wireframes for chat assistant, dashboards, and asset views.
+2. Prototype backend services for metrics retrieval and trace logging.
+3. Implement accessibility toggles for professional/beginner modes.
+4. Integrate Mistral data pipelines and DeepSeek model endpoints.
+5. Iterate with user testing to refine the interface and workflow.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "mlflow>=2.7,<3",
     "SQLAlchemy>=2.0,<3",
     "psutil>=5.9,<6",
-    "optuna>=3,<4"
+    "optuna>=3,<4",
+    "fastapi>=0.110,<1"
 ]
 
 [project.optional-dependencies]

--- a/src/sentimental_cap_predictor/ui/__init__.py
+++ b/src/sentimental_cap_predictor/ui/__init__.py
@@ -1,0 +1,1 @@
+"""User-facing API and utilities for the CAP predictor UI."""

--- a/src/sentimental_cap_predictor/ui/api.py
+++ b/src/sentimental_cap_predictor/ui/api.py
@@ -1,0 +1,64 @@
+"""FastAPI application exposing endpoints for chat, model metrics,
+asset performance and decision traceability.
+
+This skeleton implements the UI concept described in the documentation.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="CAP Predictor UI")
+
+
+class ChatMessage(BaseModel):
+    """Incoming message for the chatbot."""
+
+    message: str
+
+
+class ChatResponse(BaseModel):
+    """Response returned by the chatbot."""
+
+    id: str
+    response: str
+
+
+# Simple in-memory store to keep conversation state during the session.
+_chat_history: list[ChatResponse] = []
+
+
+@app.post("/chat", response_model=ChatResponse)
+def chat(msg: ChatMessage) -> ChatResponse:
+    """Return a placeholder response for a chat message.
+
+    In a full implementation this would call an LLM to generate a reply.
+    """
+
+    resp = ChatResponse(id=str(uuid4()), response=f"Echo: {msg.message}")
+    _chat_history.append(resp)
+    return resp
+
+
+@app.get("/metrics/{model_type}")
+def get_metrics(model_type: str) -> dict[str, float | str]:
+    """Return placeholder metrics for the requested model type."""
+
+    return {"model": model_type, "accuracy": 0.0, "latency": 0.0}
+
+
+@app.get("/assets/{asset_id}/performance")
+def asset_performance(asset_id: str) -> dict[str, list[float] | str]:
+    """Return placeholder asset-level performance data."""
+
+    return {"asset": asset_id, "predictions": [], "actuals": []}
+
+
+@app.get("/trace/{prediction_id}")
+def trace(prediction_id: str) -> dict[str, str | list[str]]:
+    """Return placeholder decision trace for a prediction."""
+
+    return {"prediction_id": prediction_id, "trace": []}

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+
+from sentimental_cap_predictor.ui.api import app
+
+client = TestClient(app)
+
+
+def test_chat_endpoint():
+    response = client.post("/chat", json={"message": "hello"})
+    assert response.status_code == 200
+    data = response.json()
+    assert "id" in data
+    assert data["response"].startswith("Echo:")
+
+
+def test_metrics_endpoint():
+    response = client.get("/metrics/main")
+    assert response.status_code == 200
+    assert response.json()["model"] == "main"
+
+
+def test_asset_performance_endpoint():
+    response = client.get("/assets/demo/performance")
+    assert response.status_code == 200
+    assert response.json()["asset"] == "demo"
+
+
+def test_trace_endpoint():
+    response = client.get("/trace/123")
+    assert response.status_code == 200
+    assert response.json()["prediction_id"] == "123"


### PR DESCRIPTION
## Summary
- implement minimal FastAPI application with chat, metrics, asset performance and traceability endpoints
- add tests covering the new API endpoints
- include FastAPI in project dependencies

## Testing
- `pre-commit run --files pyproject.toml src/sentimental_cap_predictor/ui/api.py src/sentimental_cap_predictor/ui/__init__.py tests/test_ui_api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76906855c832b92c31bb336fab166