### PR TITLE
feat: add streamlit UI scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format test
+.PHONY: install lint format test streamlit
 
 install:
 	pip install -e .[dev]
@@ -10,4 +10,7 @@ format:
 	pre-commit run ruff-format --all-files
 
 test:
-	pytest
+        pytest
+
+streamlit:
+        streamlit run src/sentimental_cap_predictor/ui/streamlit_app.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dev = [
     "ruff>=0.1.5,<0.2",
     "pre-commit>=3.5,<4",
 ]
+ui = [
+    "streamlit>=1,<2",
+]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/sentimental_cap_predictor/ui/streamlit_app.py
+++ b/src/sentimental_cap_predictor/ui/streamlit_app.py
@@ -1,0 +1,10 @@
+"""Minimal Streamlit UI for the CAP Predictor project."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+st.set_page_config(page_title="CAP Predictor")
+
+st.title("CAP Predictor")
+st.write("Welcome to the CAP Predictor Streamlit interface.")


### PR DESCRIPTION
## Summary
- add minimal Streamlit app
- declare streamlit optional dependency
- provide `make streamlit` target for launching the app

## Testing
- `pre-commit run --files pyproject.toml Makefile src/sentimental_cap_predictor/ui/streamlit_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77da98a0c832b85de6d81cc0de001