### PR TITLE
Add experiment comparison chatbot to CLI

### DIFF
--- a/tests/test_experiment_chatbot.py
+++ b/tests/test_experiment_chatbot.py
@@ -1,0 +1,15 @@
+from sentimental_cap_predictor.experiment import (
+    ExperimentTracker,
+    _handle_question,
+)
+
+
+def test_handle_question_compare(tmp_path):
+    tracker = ExperimentTracker(db_path=tmp_path / "experiments.db")
+    run_a = tracker.log("code", {}, {"accuracy": 0.9}, {})
+    run_b = tracker.log("code", {}, {"accuracy": 0.8}, {})
+    msg = f"compare {run_a} {run_b} metric=accuracy"
+    response = _handle_question(msg, tracker)
+    assert str(run_a) in response
+    assert "accuracy" in response
+    assert "0.9" in response and "0.8" in response


### PR DESCRIPTION
## Summary
- add `_compare_explanation` and `_handle_question` helpers to analyze experiment metrics
- expose new `chat` command for interactive run comparisons with reasoning
- cover chatbot comparison logic with unit test

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/experiment.py tests/test_experiment_chatbot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a79e39f6e4832baaf4f0224556ca2f