### PR TITLE
Add OpenAI-powered CLI chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.dataset` – download price and news data
 - `sentimental_cap_predictor.plots` – visualize processed data
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
+- `sentimental_cap_predictor.chatbot` – chat with an OpenAI-powered assistant that consults main and experimental models and explains its decisions (requires `OPENAI_API_KEY`)
 
 Run `--help` with any module for detailed options.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,6 +84,20 @@ python -m sentimental_cap_predictor.scheduler ideas:generate "interest rate regi
 
 This command can be scheduled with cron in the same way as the daily pipeline.
 
+## Chatbot
+
+Interact with an OpenAI-powered assistant from the terminal. The chatbot
+queries both a *main* and an *experimental* model for every question and
+explains which answer was chosen:
+
+```bash
+python -m sentimental_cap_predictor.chatbot chat \
+    --main-model gpt-3.5-turbo \
+    --experimental-model gpt-4o-mini
+```
+
+Set `OPENAI_API_KEY` in your environment before using the command.
+
 ## GitHub Repository Data
 
 Utilities that pull information from the GitHub API can optionally use a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "mlflow>=2.7,<3",
     "SQLAlchemy>=2.0,<3",
     "psutil>=5.9,<6",
-    "optuna>=3,<4"
+    "optuna>=3,<4",
+    "openai>=1,<2"
 ]
 
 [project.optional-dependencies]

--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -1,0 +1,102 @@
+"""Simple command-line chatbot powered by OpenAI models."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Tuple
+
+import typer
+
+try:  # pragma: no cover - external dependency
+    from openai import OpenAI
+except Exception:  # pragma: no cover - handled at runtime
+    OpenAI = None  # type: ignore[misc, assignment]
+
+
+app = typer.Typer(
+    help="Interactive chatbot using OpenAI's chat completions API",
+)
+
+
+def _client() -> OpenAI:
+    """Return an OpenAI client configured from environment variables."""
+
+    if OpenAI is None:  # pragma: no cover - import guard
+        raise typer.BadParameter("openai package is not installed")
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        msg = "OPENAI_API_KEY environment variable is missing"
+        raise typer.BadParameter(msg)
+    return OpenAI(api_key=api_key)
+
+
+def _ask(
+    client: OpenAI,
+    model: str,
+    history: List[Dict[str, str]],
+) -> Tuple[str, List[Dict[str, str]]]:
+    """Send the current history to ``model`` and append the reply.
+
+    Returns the model's reply and updated history. Network failures propagate
+    to the caller so they can be surfaced to the user.
+    """
+
+    resp = client.chat.completions.create(model=model, messages=history)
+    reply = resp.choices[0].message.content or ""
+    history.append({"role": "assistant", "content": reply})
+    return reply, history
+
+
+def _summarize_decision(main_reply: str, exp_reply: str) -> str:
+    """Explain how the final response was selected.
+
+    The function compares outputs from the main and experimental models and
+    returns a human-readable explanation describing any differences and which
+    response was chosen.
+    """
+
+    if main_reply.strip() == exp_reply.strip():
+        return f"Both models agree: {main_reply}"
+    return (
+        "Main model replied: {main}.\nExperimental model replied: {exp}.\n"
+        "Decision: opting for the main model's answer because it is the "
+        "production model while the experimental model is still under "
+        "evaluation."
+    ).format(main=main_reply, exp=exp_reply)
+
+
+@app.command()
+def chat(
+    main_model: str = "gpt-3.5-turbo",
+    experimental_model: str = "gpt-4o-mini",
+) -> None:  # pragma: no cover - CLI wrapper
+    """Start an interactive chat session consulting two models.
+
+    The chatbot queries both a *main* and an *experimental* model for every
+    question. It then reports which answer was chosen and why. Provide a valid
+    ``OPENAI_API_KEY`` environment variable before running the command. Type
+    ``exit`` or ``quit`` to end the session.
+    """
+
+    client = _client()
+    main_hist: List[Dict[str, str]] = []
+    exp_hist: List[Dict[str, str]] = []
+    typer.echo("Chatbot ready. Type 'exit' to quit.")
+    while True:
+        user = typer.prompt("You")
+        if user.strip().lower() in {"exit", "quit"}:
+            break
+        main_hist.append({"role": "user", "content": user})
+        exp_hist.append({"role": "user", "content": user})
+        try:
+            main_reply, main_hist = _ask(client, main_model, main_hist)
+            exp_reply, exp_hist = _ask(client, experimental_model, exp_hist)
+        except Exception as exc:  # pragma: no cover - network failure
+            typer.echo(f"Error: {exc}")
+            break
+        summary = _summarize_decision(main_reply, exp_reply)
+        typer.echo(f"Bot: {summary}")
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    app()

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,0 +1,11 @@
+from sentimental_cap_predictor.chatbot import _summarize_decision
+
+
+def test_summarize_decision_agreement():
+    result = _summarize_decision("yes", "yes")
+    assert "both models agree" in result.lower()
+
+
+def test_summarize_decision_disagreement():
+    result = _summarize_decision("yes", "no")
+    assert "main model" in result.lower() and "experimental" in result.lower()


### PR DESCRIPTION
## Summary
- add Typer-based chatbot module using OpenAI's chat completions API
- allow chatbot to consult main and experimental models and explain which answer was chosen
- document chatbot usage with model comparison options

## Testing
- `pre-commit run --files README.md docs/cli.md src/sentimental_cap_predictor/chatbot.py tests/test_chatbot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7a978d2f4832bb0758425049212b4