### PR TITLE
docs: simplify chatbot invocation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,7 +91,7 @@ chatbot queries both a *main* and an *experimental* model for every question
 and explains which answer was chosen:
 
 ```bash
-python -m sentimental_cap_predictor.chatbot chat \
+python -m sentimental_cap_predictor.chatbot \
     --main-model mistralai/Mistral-7B-v0.1 \
     --experimental-model mistralai/Mistral-7B-Instruct-v0.2
 ```


### PR DESCRIPTION
## Summary
- remove stray `chat` argument from chatbot CLI example
- confirm no other documentation uses the old subcommand

## Testing
- `pre-commit run --files docs/cli.md`
- `OFFLINE_TEST=1 pytest` *(fails: ImportError: lxml.html.clean module is now a separate project lxml_html_clean)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c18f7678832b98a47d9d7239198d