### PR TITLE
Use env-configurable default for idea generation model

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -82,9 +82,10 @@ write them to a JSON file:
 python -m sentimental_cap_predictor.scheduler ideas:generate "interest rate regimes" --output ideas.json
 ```
 
-This command can be scheduled with cron in the same way as the daily pipeline.
-The underlying model defaults to the value of the `MAIN_MODEL` environment
-variable or `Qwen/Qwen2-7B-Instruct` if the variable is unset.
+The model ID defaults to the `MAIN_MODEL` environment variable or
+`Qwen/Qwen2-7B-Instruct` if the variable is unset. Override it for a single
+run with the `--model-id` option. This command can be scheduled with cron in
+the same way as the daily pipeline.
 
 ## Chatbot
 

--- a/tests/research/test_idea_generator_local.py
+++ b/tests/research/test_idea_generator_local.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 from dataclasses import asdict
 
@@ -5,15 +6,36 @@ from sentimental_cap_predictor.research import idea_generator
 
 
 class _StubPipeline:
-    def __call__(self, prompt, max_new_tokens=512, do_sample=True, temperature=0.2):
+    def __call__(
+        self,
+        prompt,
+        max_new_tokens=512,
+        do_sample=True,
+        temperature=0.2,
+    ):
         data = [{"name": "Idea", "description": "desc", "params": {"x": 1}}]
         return [{"generated_text": json.dumps(data)}]
 
 
 def test_generate_ideas_parses_json(monkeypatch):
-    monkeypatch.setattr(idea_generator, "_get_pipeline", lambda model_id: _StubPipeline())
+    monkeypatch.setattr(
+        idea_generator, "_get_pipeline", lambda model_id: _StubPipeline()
+    )
     ideas = idea_generator.generate_ideas("topic", model_id="dummy", n=1)
     assert [asdict(i) for i in ideas] == [
         {"name": "Idea", "description": "desc", "params": {"x": 1}}
     ]
 
+
+def test_generate_ideas_uses_env_default(monkeypatch):
+    called = {}
+
+    def _stub(model_id):
+        called["model"] = model_id
+        return _StubPipeline()
+
+    monkeypatch.setenv("MAIN_MODEL", "env-model")
+    importlib.reload(idea_generator)
+    monkeypatch.setattr(idea_generator, "_get_pipeline", _stub)
+    idea_generator.generate_ideas("topic", n=1)
+    assert called["model"] == "env-model"


### PR DESCRIPTION
## Summary
- load environment variables when module imports
- default idea-generation model is now read from `MAIN_MODEL`
- document `--model-id` override and env var default

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/research/idea_generator.py tests/research/test_idea_generator_local.py docs/cli.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7cfd5c038832b89b49a897ac9d061