### PR TITLE
Avoid TensorFlow import in chatbot pipeline

### DIFF
--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -12,8 +12,14 @@ def _get_pipeline(model_id: str):
 
     import os
 
-    os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
-    os.environ.setdefault("TRANSFORMERS_NO_FLAX", "1")
+    # Disable optional backends that can trigger heavy imports or incompatibilities
+    # on systems where TensorFlow or Flax are installed but not fully configured.
+    # Using ``setdefault`` would keep any pre-existing environment values and may
+    # therefore fail to turn off those frameworks. Assigning explicitly ensures
+    # the flag is always honored, preventing unexpected TensorFlow imports such as
+    # the one causing a ``google.protobuf.runtime_version`` error.
+    os.environ["TRANSFORMERS_NO_TF"] = "1"
+    os.environ["TRANSFORMERS_NO_FLAX"] = "1"
     from transformers import pipeline
 
     return pipeline("text-generation", model=model_id, tokenizer=model_id)


### PR DESCRIPTION
## Summary
- ensure chat pipeline disables TensorFlow and Flax backends to prevent protobuf runtime errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a898ee07dc832bb03dc6272e9279e6