### PR TITLE
Switch chatbot to Qwen defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.dataset` – download price and news data
 - `sentimental_cap_predictor.plots` – visualize processed data
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
-- `sentimental_cap_predictor.chatbot` – chat with a local Mistral-powered assistant that consults main and experimental models and explains its decisions
+- `sentimental_cap_predictor.chatbot` – chat with a local Qwen-powered assistant that consults main and experimental models and explains its decisions
 
 Run `--help` with any module for detailed options.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,14 +89,14 @@ the same way as the daily pipeline.
 
 ## Chatbot
 
-Interact with a local Mistral-powered assistant from the terminal. The
+Interact with a small Qwen-powered assistant from the terminal. The
 chatbot queries both a *main* and an *experimental* model for every question
 and explains which answer was chosen:
 
 ```bash
 python -m sentimental_cap_predictor.chatbot \
-    --main-model mistralai/Mistral-7B-v0.1 \
-    --experimental-model mistralai/Mistral-7B-Instruct-v0.2
+    --main-model Qwen/Qwen2-0.5B-Instruct \
+    --experimental-model Qwen/Qwen2-0.5B
 ```
 
 ## GitHub Repository Data

--- a/docs/ui_proposal.md
+++ b/docs/ui_proposal.md
@@ -1,6 +1,6 @@
 # CAP Predictor UI Proposal
 
-This document outlines a user-accessible UI for the CAP Predictor platform. It incorporates a persistent chatbot assistant, monitoring dashboards, asset-level performance views, decision-traceability, and accessibility considerations. It also sketches integration points with Mistral data sourcing and DeepSeek implementations.
+This document outlines a user-accessible UI for the CAP Predictor platform. It incorporates a persistent chatbot assistant, monitoring dashboards, asset-level performance views, decision-traceability, and accessibility considerations. It also sketches integration points with Qwen data sourcing and DeepSeek implementations.
 
 ## 1. Persistent Chatbot Assistant
 - Docked chat panel that remains visible across screens, powered by an LLM.
@@ -27,20 +27,20 @@ This document outlines a user-accessible UI for the CAP Predictor platform. It i
 - **Beginner Mode**: simplified visuals with guided tooltips and walkthroughs.
 - WCAG-compliant colors, keyboard navigation, ARIA roles, adjustable fonts, and dark/light themes.
 
-## 6. Integration with Mistral and DeepSeek
-- **Mistral Data Sourcing**: dashboard panel shows dataset provenance, update schedules, and quality metrics derived from Mistral pipelines. Chatbot can reference data lineage when answering questions.
+## 6. Integration with Qwen and DeepSeek
+- **Qwen Data Sourcing**: dashboard panel shows dataset provenance, update schedules, and quality metrics derived from Qwen pipelines. Chatbot can reference data lineage when answering questions.
 - **DeepSeek Implementations**: experimental models deployed on DeepSeek infrastructure with metrics surfaced in dashboards. Decision traces link to DeepSeek-hosted model configs.
 
 ## 7. Technology Stack
 - Frontend: React + TypeScript using a component library and Plotly/D3 for charts.
 - Backend: FastAPI routes backed by PostgreSQL and Redis; WebSockets for live metrics.
-- Chatbot: Mistral or DeepSeek LLM APIs with a context manager for conversation state.
+- Chatbot: Qwen or DeepSeek LLM APIs with a context manager for conversation state.
 - Deployment: Dockerized services orchestrated with Kubernetes for scalability and resilience.
 
 ## 8. Next Steps
 1. Create wireframes for chat assistant, dashboards, and asset views.
 2. Prototype backend services for metrics retrieval and trace logging.
 3. Implement accessibility toggles for professional/beginner modes.
-4. Integrate Mistral data pipelines and DeepSeek model endpoints.
+4. Integrate Qwen data pipelines and DeepSeek model endpoints.
 5. Iterate with user testing to refine the interface and workflow.
 

--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -1,4 +1,4 @@
-"""Simple command-line chatbot powered by local Mistral models."""
+"""Simple command-line chatbot powered by small Qwen models."""
 
 import typer
 
@@ -12,8 +12,14 @@ def _get_pipeline(model_id: str):
 
     import os
 
-    os.environ.setdefault("TRANSFORMERS_NO_TF", "1")
-    os.environ.setdefault("TRANSFORMERS_NO_FLAX", "1")
+    # Disable optional backends that can trigger heavy imports or incompatibilities
+    # on systems where TensorFlow or Flax are installed but not fully configured.
+    # ``transformers`` checks the ``USE_TF`` and ``USE_FLAX`` environment
+    # variables when deciding whether to import those frameworks. Setting them
+    # to ``0`` prevents expensive imports that can lead to protobuf runtime
+    # errors on machines that happen to have TensorFlow installed.
+    os.environ.setdefault("USE_TF", "0")
+    os.environ.setdefault("USE_FLAX", "0")
     from transformers import pipeline
 
     return pipeline("text-generation", model=model_id, tokenizer=model_id)
@@ -55,8 +61,8 @@ def _summarize_decision(main_reply: str, exp_reply: str) -> str:
 
 @app.command()
 def chat(
-    main_model: str = "mistralai/Mistral-7B-v0.1",
-    experimental_model: str = "mistralai/Mistral-7B-Instruct-v0.2",
+    main_model: str = "Qwen/Qwen2-0.5B-Instruct",
+    experimental_model: str = "Qwen/Qwen2-0.5B",
 ) -> None:  # pragma: no cover - CLI wrapper
     """Start an interactive chat session consulting two local models.
 


### PR DESCRIPTION
## Summary
- default chatbot to small Qwen models instead of Mistral
- document Qwen usage throughout CLI and UI proposal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a898ee07dc832bb03dc6272e9279e6