### PR TITLE
feat: enable command execution in chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.dataset` – download price and news data
 - `sentimental_cap_predictor.plots` – visualize processed data
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
-- `sentimental_cap_predictor.chatbot` – chat with a local Qwen-powered assistant that consults main and experimental models and explains its decisions
+- `sentimental_cap_predictor.chatbot` – chat with a local Qwen-powered assistant that consults main and experimental models, explains its decisions, and can execute shell commands when a reply starts with `CMD:`
 
 Run `--help` with any module for detailed options.
 

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,4 +1,8 @@
-from sentimental_cap_predictor.chatbot import _summarize_decision
+from sentimental_cap_predictor.chatbot import (
+    SYSTEM_PROMPT,
+    _run_shell,
+    _summarize_decision,
+)
 
 
 def test_summarize_decision_agreement():
@@ -9,3 +13,12 @@ def test_summarize_decision_agreement():
 def test_summarize_decision_disagreement():
     result = _summarize_decision("yes", "no")
     assert "main model" in result.lower() and "experimental" in result.lower()
+
+
+def test_run_shell_executes_command():
+    output = _run_shell("echo hello")
+    assert "hello" in output
+
+
+def test_system_prompt_mentions_cli():
+    assert "command-line assistant" in SYSTEM_PROMPT.lower()


### PR DESCRIPTION
## Summary
- allow the chatbot's main model to request shell commands via `CMD:` and return output
- document command execution in README and give the model a system prompt describing CLI modules
- add unit tests for shell execution and system prompt

## Testing
- `pre-commit run --files README.md src/sentimental_cap_predictor/chatbot.py tests/test_chatbot.py`
- `pytest tests/test_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a2178ea4832b9bdd996d462d1b8a