### PR TITLE
feat: enable command execution in chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.dataset` – download price and news data
 - `sentimental_cap_predictor.plots` – visualize processed data
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
-- `sentimental_cap_predictor.chatbot` – chat with a local Qwen-powered assistant that consults main and experimental models and explains its decisions
+- `sentimental_cap_predictor.chatbot` – chat with a local Qwen-powered assistant that consults main and experimental models, explains its decisions, and can execute shell commands when a reply starts with `CMD:`. Only commands for the modules listed here are run, and their output is shown before the assistant's final response.
 
 Run `--help` with any module for detailed options.
 

--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -1,4 +1,15 @@
-"""Simple command-line chatbot powered by small Qwen models."""
+"""Simple command-line chatbot powered by small Qwen models.
+
+The assistant can run shell commands when prompted. If a model reply starts
+with ``CMD:`` followed by a command, the command is executed locally and the
+output is appended to the conversation history before asking the model for a
+final explanation.
+"""
+
+import os
+import shlex
+import subprocess
+from pathlib import Path
 
 import typer
 
@@ -12,12 +23,13 @@ def _get_pipeline(model_id: str):
 
     import os
 
-    # Disable optional backends that can trigger heavy imports or incompatibilities
-    # on systems where TensorFlow or Flax are installed but not fully configured.
-    # ``transformers`` checks the ``USE_TF`` and ``USE_FLAX`` environment
-    # variables when deciding whether to import those frameworks. Setting them
-    # to ``0`` prevents expensive imports that can lead to protobuf runtime
-    # errors on machines that happen to have TensorFlow installed.
+    # Disable optional backends that can trigger heavy imports or
+    # incompatibilities on systems where TensorFlow or Flax are installed
+    # but not fully configured. ``transformers`` checks the ``USE_TF`` and
+    # ``USE_FLAX`` environment variables when deciding whether to import
+    # those frameworks. Setting them to ``0`` prevents expensive imports that
+    # can lead to protobuf runtime errors on machines that happen to have
+    # TensorFlow installed.
     os.environ.setdefault("USE_TF", "0")
     os.environ.setdefault("USE_FLAX", "0")
     from transformers import pipeline
@@ -59,6 +71,61 @@ def _summarize_decision(main_reply: str, exp_reply: str) -> str:
     ).format(main=main_reply, exp=exp_reply)
 
 
+SYSTEM_PROMPT = (
+    "System: You are a command-line assistant for the sentimental CAP "
+    "predictor project. You can execute shell commands for the user. To "
+    "run a command, reply with 'CMD: <command>'. After seeing the command "
+    "output you should provide a helpful explanation."
+)
+
+CLI_USAGE = (
+    "System: Available CLI modules include dataset, plots, "
+    "modeling.sentiment_analysis and chatbot. They can be invoked with "
+    "'python -m sentimental_cap_predictor.<module>'. Only these commands "
+    "will be executed."
+)
+
+
+ALLOWED_MODULES = {
+    "dataset",
+    "plots",
+    "modeling.sentiment_analysis",
+    "chatbot",
+}
+
+
+def _run_shell(command: str) -> str:
+    """Execute ``command`` in the system shell and return its output.
+
+    Only ``python -m sentimental_cap_predictor.<module>`` commands where
+    ``<module>`` is in :data:`ALLOWED_MODULES` are permitted. Any other
+    command returns an error message without being executed.
+    """
+
+    parts = shlex.split(command)
+    if len(parts) >= 3 and parts[0] == "python" and parts[1] == "-m":
+        module = parts[2].removeprefix("sentimental_cap_predictor.")
+        if (
+            parts[2].startswith("sentimental_cap_predictor.")
+            and module in ALLOWED_MODULES
+        ):
+            src_dir = Path(__file__).resolve().parents[1]
+            project_root = src_dir.parent
+            env = os.environ.copy()
+            env["PYTHONPATH"] = f"{src_dir}:{env.get('PYTHONPATH', '')}"
+            result = subprocess.run(
+                command,
+                shell=True,
+                check=False,
+                capture_output=True,
+                text=True,
+                cwd=project_root,
+                env=env,
+            )
+            return f"{result.stdout}{result.stderr}".strip()
+    return "Command not allowed."
+
+
 @app.command()
 def chat(
     main_model: str = "Qwen/Qwen2-0.5B-Instruct",
@@ -73,8 +140,8 @@ def chat(
 
     main_gen = _get_pipeline(main_model)
     exp_gen = _get_pipeline(experimental_model)
-    main_hist: list[str] = []
-    exp_hist: list[str] = []
+    main_hist: list[str] = [SYSTEM_PROMPT, CLI_USAGE]
+    exp_hist: list[str] = [SYSTEM_PROMPT, CLI_USAGE]
     typer.echo("Chatbot ready. Type 'exit' to quit.")
     while True:
         user = typer.prompt("You")
@@ -82,6 +149,16 @@ def chat(
             break
         try:
             main_reply, main_hist = _ask(main_gen, main_hist, user)
+            if main_reply.startswith("CMD:"):
+                cmd = main_reply.removeprefix("CMD:").strip()
+                cmd_output = _run_shell(cmd)
+                typer.echo(cmd_output)
+                main_hist.append(f"System: Command output:\n{cmd_output}")
+                main_reply, main_hist = _ask(
+                    main_gen,
+                    main_hist,
+                    "Command executed.",
+                )
             exp_reply, exp_hist = _ask(exp_gen, exp_hist, user)
         except Exception as exc:  # pragma: no cover - model failure
             typer.echo(f"Error: {exc}")

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,4 +1,8 @@
-from sentimental_cap_predictor.chatbot import _summarize_decision
+from sentimental_cap_predictor.chatbot import (
+    SYSTEM_PROMPT,
+    _run_shell,
+    _summarize_decision,
+)
 
 
 def test_summarize_decision_agreement():
@@ -9,3 +13,17 @@ def test_summarize_decision_agreement():
 def test_summarize_decision_disagreement():
     result = _summarize_decision("yes", "no")
     assert "main model" in result.lower() and "experimental" in result.lower()
+
+
+def test_run_shell_executes_command():
+    output = _run_shell("python -m sentimental_cap_predictor.chatbot --help")
+    assert "usage" in output.lower()
+
+
+def test_run_shell_rejects_unlisted_command():
+    output = _run_shell("echo hello")
+    assert "not allowed" in output.lower()
+
+
+def test_system_prompt_mentions_cli():
+    assert "command-line assistant" in SYSTEM_PROMPT.lower()


### PR DESCRIPTION
## Summary
- restrict command execution to approved CLI modules and print output before responding
- describe command sandboxing in CLI docs
- test allowed and disallowed command execution paths

## Testing
- `pre-commit run --files README.md src/sentimental_cap_predictor/chatbot.py tests/test_chatbot.py`
- `pytest tests/test_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a2178ea4832b9bdd996d462d1b8a