### PR TITLE
Teach chatbot its community purpose

### DIFF
--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -71,11 +71,37 @@ def _summarize_decision(main_reply: str, exp_reply: str) -> str:
     ).format(main=main_reply, exp=exp_reply)
 
 
+MISSION_STATEMENT = (
+    "A Model for the Community\n\n"
+    "We build this model not only to predict markets, but to reclaim our most "
+    "valuable resource: time.\n\n"
+    "In today’s world, information is locked away, and efficiency is "
+    "hoarded by those with wealth and power. Ordinary people are left to "
+    "work longer hours, carrying the burden of complexity without sharing "
+    "in the benefits.\n\n"
+    "This project is different.\n"
+    "It is designed to free people from repetitive, isolating labor — not to "
+    "extract profit, but to create space. Space for families, for neighbors, "
+    "for art, for rest, for learning, for organizing.\n\n"
+    "The insights generated here will be shared through a data cooperative: a "
+    "commons where knowledge and tools belong to the community that "
+    "creates them. We believe that when data and technology are governed "
+    "democratically, they become engines for solidarity rather than "
+    "exploitation.\n\n"
+    "This model is not an end in itself. It is a step toward a society where "
+    "tools serve people, and where freed time can be used to build "
+    "something better together.\n\n"
+    "We commit to building technology that strengthens community, distributes "
+    "power, and helps us imagine new ways of living well."
+)
+
+
 SYSTEM_PROMPT = (
     "System: You are a command-line assistant for the sentimental CAP "
     "predictor project. You can execute shell commands for the user. To "
     "run a command, reply with 'CMD: <command>'. After seeing the command "
-    "output you should provide a helpful explanation."
+    "output you should provide a helpful explanation.\n\n"
+    f"{MISSION_STATEMENT}"
 )
 
 CLI_USAGE = (

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sentimental_cap_predictor.chatbot import (
+    MISSION_STATEMENT,
     SYSTEM_PROMPT,
     _run_shell,
     _summarize_decision,
@@ -45,3 +46,7 @@ def test_run_shell_blocks_injection():
 
 def test_system_prompt_mentions_cli():
     assert "command-line assistant" in SYSTEM_PROMPT.lower()
+
+
+def test_system_prompt_mentions_mission():
+    assert MISSION_STATEMENT in SYSTEM_PROMPT


### PR DESCRIPTION
## Summary
- teach chatbot its community purpose via explicit mission statement
- ensure system prompt embeds project mission
- test mission inclusion in system prompt

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot.py tests/test_chatbot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b3e44aec832bb2daceeddb380ed3