### PR TITLE
Simplify chatbot to single model

### DIFF
--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -4,19 +4,7 @@ from sentimental_cap_predictor.chatbot import (
     MISSION_STATEMENT,
     SYSTEM_PROMPT,
     _run_shell,
-    _summarize_decision,
 )
-
-
-def test_summarize_decision_agreement():
-    result = _summarize_decision("yes", "yes")
-    assert "both models agree" in result.lower()
-
-
-def test_summarize_decision_disagreement():
-    result = _summarize_decision("yes", "no")
-    assert "main model" in result.lower() and "experimental" in result.lower()
-
 
 @pytest.mark.parametrize(
     "module,expected",


### PR DESCRIPTION
## Summary
- simplify chatbot to consult only one instruct-tuned model
- drop unused decision comparison helper
- adjust chatbot tests to match single-model design

## Testing
- `pytest tests/test_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8bd7e54b4832bb16b4823c484faa5