### PR TITLE
feat: add color themes to chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.modeling.train_eval` – train and validate predictive models
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
 - `sentimental_cap_predictor.plots` – visualize processed data
-- `sentimental_cap_predictor.chatbot` – chat with a local Qwen-powered assistant that consults main and experimental models, explains its decisions, and can execute shell commands when a reply starts with `CMD:`. Only commands for the modules listed here are run, and their output is shown before the assistant's final response.
+- `sentimental_cap_predictor.chatbot` – chat with a local Qwen-powered assistant that consults main and experimental models, explains its decisions, and can execute shell commands when a reply starts with `CMD:`. Output is color-coded for readability and accessibility; choose a theme with `--theme` or disable colors with `--no-color`. Only commands for the modules listed here are run, and their output is shown before the assistant's final response.
 
 When the assistant executes a command it prints a short status message (e.g.,
 "Ingesting data..." or "Running back-testing engine...") so you know work is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,6 +99,10 @@ python -m sentimental_cap_predictor.chatbot \
     --experimental-model Qwen/Qwen2-0.5B
 ```
 
+The interface color-codes user, assistant, system, command, and error messages.
+Select `--theme high-contrast` for a brighter palette or disable colors with
+`--no-color`.
+
 ## GitHub Repository Data
 
 Utilities that pull information from the GitHub API can optionally use a

--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -9,6 +9,7 @@ final explanation.
 import os
 import shlex
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import typer
@@ -16,6 +17,24 @@ import typer
 app = typer.Typer(
     help="Interactive chatbot using local Hugging Face models",
 )
+
+
+THEMES = {
+    "default": {
+        "user": {"fg": typer.colors.CYAN},
+        "bot": {"fg": typer.colors.GREEN},
+        "system": {"fg": typer.colors.YELLOW},
+        "command": {"fg": typer.colors.MAGENTA},
+        "error": {"fg": typer.colors.RED},
+    },
+    "high-contrast": {
+        "user": {"fg": typer.colors.BRIGHT_CYAN, "bold": True},
+        "bot": {"fg": typer.colors.BRIGHT_GREEN, "bold": True},
+        "system": {"fg": typer.colors.BRIGHT_YELLOW, "bold": True},
+        "command": {"fg": typer.colors.BRIGHT_MAGENTA, "bold": True},
+        "error": {"fg": typer.colors.BRIGHT_RED, "bold": True},
+    },
+}
 
 
 def _get_pipeline(model_id: str):
@@ -117,13 +136,23 @@ LOADING_MESSAGES = {
 }
 
 
-def _run_shell(command: str) -> str:
+def _run_shell(
+    command: str,
+    style: Callable[[str, str], str] | None = None,
+) -> str:
     """Execute ``command`` in the system shell and return its output.
 
     Only ``python -m sentimental_cap_predictor.<module>`` commands where
     ``<module>`` is in :data:`ALLOWED_MODULES` are permitted. Any other
     command returns an error message without being executed.
     """
+
+    if style is None:
+
+        def style_fn(text: str, role: str = "system") -> str:
+            return text
+
+        style = style_fn
 
     parts = shlex.split(command)
     if len(parts) >= 3 and parts[0] == "python" and parts[1] == "-m":
@@ -132,7 +161,8 @@ def _run_shell(command: str) -> str:
             parts[2].startswith("sentimental_cap_predictor.")
             and module in ALLOWED_MODULES
         ):
-            typer.echo(LOADING_MESSAGES.get(module, "Thinking..."))
+            message = LOADING_MESSAGES.get(module, "Thinking...")
+            typer.echo(style(message, "system"))
             src_dir = Path(__file__).resolve().parents[1]
             project_root = src_dir.parent
             env = os.environ.copy()
@@ -152,26 +182,37 @@ def _run_shell(command: str) -> str:
 @app.command()
 def chat(
     main_model: str = "Qwen/Qwen2-0.5B-Instruct",
+    theme: str = typer.Option(
+        "default", help="Color theme for output (default or high-contrast)."
+    ),
+    no_color: bool = typer.Option(False, help="Disable colored output."),
 ) -> None:  # pragma: no cover - CLI wrapper
     """Start an interactive chat session using a single local model.
 
-    The chatbot queries an instruct-tuned model for each question. Type ``exit``
-    or ``quit`` to end the session.
+    The chatbot queries an instruct-tuned model for each question.
+    Type ``exit`` or ``quit`` to end the session.
     """
+
+    theme_styles = THEMES.get(theme.lower(), THEMES["default"])
+
+    def style(text: str, role: str) -> str:
+        if no_color:
+            return text
+        return typer.style(text, **theme_styles[role])
 
     generator = _get_pipeline(main_model)
     history: list[str] = [SYSTEM_PROMPT, CLI_USAGE]
-    typer.echo("Chatbot ready. Type 'exit' to quit.")
+    typer.echo(style("Chatbot ready. Type 'exit' to quit.", "system"))
     while True:
-        user = typer.prompt("You")
+        user = typer.prompt(style("You", "user"))
         if user.strip().lower() in {"exit", "quit"}:
             break
         try:
             reply, history = _ask(generator, history, user)
             if reply.startswith("CMD:"):
                 cmd = reply.removeprefix("CMD:").strip()
-                cmd_output = _run_shell(cmd)
-                typer.echo(cmd_output)
+                cmd_output = _run_shell(cmd, style)
+                typer.echo(style(cmd_output, "command"))
                 history.append(f"System: Command output:\n{cmd_output}")
                 reply, history = _ask(
                     generator,
@@ -179,9 +220,9 @@ def chat(
                     "Command executed.",
                 )
         except Exception as exc:  # pragma: no cover - model failure
-            typer.echo(f"Error: {exc}")
+            typer.echo(style(f"Error: {exc}", "error"))
             break
-        typer.echo(f"Bot: {reply}")
+        typer.echo(style(f"Bot: {reply}", "bot"))
 
 
 if __name__ == "__main__":  # pragma: no cover - entry point


### PR DESCRIPTION
## Summary
- add default and high-contrast color themes for chatbot output
- allow disabling colors and choosing theme in CLI
- document new accessibility options in README and CLI guide

## Testing
- `pre-commit run --files README.md docs/cli.md src/sentimental_cap_predictor/chatbot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8c0613b94832bb583b14615743cca