### PR TITLE
clarify that chatbot examples aren't executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.modeling.train_eval` – train and validate predictive models
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
 - `sentimental_cap_predictor.plots` – visualize processed data
-- `sentimental_cap_predictor.chatbot` – chat with a local Qwen-powered assistant that consults main and experimental models, explains its decisions, and can execute shell commands when a reply starts with `CMD:`. Only commands for the modules listed here are run, and their output is shown before the assistant's final response.
+- `sentimental_cap_predictor.chatbot` – chat with a local Qwen-powered assistant that consults main and experimental models, explains its decisions, and can execute shell commands when a reply starts with `CMD:`. Output is color-coded for readability and accessibility; choose a theme with `--theme` or disable colors with `--no-color`. Only commands for the modules listed here are run, and their output is shown before the assistant's final response. Suggestions or code blocks without `CMD:` are examples and are not executed automatically.
 
 When the assistant executes a command it prints a short status message (e.g.,
 "Ingesting data..." or "Running back-testing engine...") so you know work is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,6 +99,12 @@ python -m sentimental_cap_predictor.chatbot \
     --experimental-model Qwen/Qwen2-0.5B
 ```
 
+The interface color-codes user, assistant, system, command, and error messages.
+Select `--theme high-contrast` for a brighter palette or disable colors with
+`--no-color`. Commands are executed only when the assistant replies with a line
+starting with `CMD:`; other suggestions or code blocks are examples and are not
+run automatically.
+
 ## GitHub Repository Data
 
 Utilities that pull information from the GitHub API can optionally use a

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -6,6 +6,7 @@ from sentimental_cap_predictor.chatbot import (
     _run_shell,
 )
 
+
 @pytest.mark.parametrize(
     "module,expected",
     [
@@ -38,3 +39,7 @@ def test_system_prompt_mentions_cli():
 
 def test_system_prompt_mentions_mission():
     assert MISSION_STATEMENT in SYSTEM_PROMPT
+
+
+def test_system_prompt_warns_about_examples():
+    assert "never claim to have run a command" in SYSTEM_PROMPT.lower()


### PR DESCRIPTION
## Summary
- warn in the system prompt and startup banner that the chatbot only runs commands when it responds with `CMD:`
- document that code snippets without `CMD:` are merely examples and aren't executed automatically
- add a regression test checking the new disclaimer

## Testing
- `pre-commit run --files README.md docs/cli.md src/sentimental_cap_predictor/chatbot.py tests/test_chatbot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8c0613b94832bb583b14615743cca