### PR TITLE
Enable manual CMD execution in chatbot

### DIFF
--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -219,6 +219,15 @@ def chat(
         user = typer.prompt(style("You", "user"))
         if user.strip().lower() in {"exit", "quit"}:
             break
+        if user.startswith("CMD:"):
+            cmd = user.removeprefix("CMD:").strip()
+            cmd_output = _run_shell(cmd, style)
+            typer.echo(style(cmd_output, "command"))
+            history.extend([
+                f"User: CMD: {cmd}",
+                f"System: Command output:\n{cmd_output}",
+            ])
+            continue
         try:
             reply, history = _ask(generator, history, user)
             if reply.startswith("CMD:"):


### PR DESCRIPTION
## Summary
- allow users to run approved modules directly by typing `CMD:` in the chatbot prompt
- record both the user command and its output in conversation history

## Testing
- `pytest tests/test_chatbot.py tests/test_experiment_chatbot.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8c5d2df40832bb2972a01c786abd0