### PR TITLE
Allow chatbot to run daily pipeline module

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,6 +62,12 @@ This downloads data, preprocesses it, trains the model, searches for an
 optimized moving‑average strategy, performs a backtest and writes a JSON summary
 to `data/processed/NVDA_daily_summary.json`.
 
+From the chatbot, prefix the same command with `CMD:` to trigger it:
+
+```text
+CMD: python -m sentimental_cap_predictor.flows.daily_pipeline run NVDA
+```
+
 ### Scheduling
 
 Use cron to execute the pipeline every weekday at 6am:

--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -121,6 +121,7 @@ CLI_USAGE = (
 ALLOWED_MODULES = {
     "dataset",
     "data.ingest",
+    "flows.daily_pipeline",
     "backtest.engine",
     "modeling.sentiment_analysis",
     "modeling.train_eval",
@@ -132,6 +133,7 @@ ALLOWED_MODULES = {
 LOADING_MESSAGES = {
     "dataset": "Analyzing dataset...",
     "data.ingest": "Ingesting data...",
+    "flows.daily_pipeline": "Running daily pipeline...",
     "backtest.engine": "Running back-testing engine...",
     "modeling.sentiment_analysis": "Analyzing sentiment...",
     "modeling.train_eval": "Training and evaluating model...",

--- a/src/sentimental_cap_predictor/flows/daily_pipeline.py
+++ b/src/sentimental_cap_predictor/flows/daily_pipeline.py
@@ -16,7 +16,6 @@ import typer
 from loguru import logger
 
 from ..data import ingest as data_ingest
-from ..model_training import train_and_predict
 from ..preprocessing import preprocess_price_data
 from ..trader_utils import strategy_optimizer as strat_opt
 
@@ -41,6 +40,7 @@ def run(
     interval: str = typer.Option("1d", help="Price interval"),
 ) -> None:
     """Execute the end-to-end daily pipeline for ``ticker``."""
+    from ..model_training import train_and_predict
     # Ingestion
     prices = data_ingest.fetch_prices(ticker, period=period, interval=interval)
     data_ingest.save_prices(prices, ticker)

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -12,6 +12,7 @@ from sentimental_cap_predictor.chatbot import (
     [
         ("chatbot", "Thinking..."),
         ("data.ingest", "Ingesting data..."),
+        ("flows.daily_pipeline", "Running daily pipeline..."),
     ],
 )
 def test_run_shell_executes_command(capsys, module, expected):


### PR DESCRIPTION
## Summary
- Permit chatbot to invoke `flows.daily_pipeline` with a dedicated loading message
- Test chatbot shell helper against the daily pipeline CLI
- Document running the daily pipeline and triggering it via the chatbot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c6b7edcc832b985d322567228f37