### PR TITLE
Add --period option to dataset CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ flowchart TD
    ```
 3. **Collect data**
    ```bash
-   python -m sentimental_cap_predictor.dataset TICKER 1Y
+   python -m sentimental_cap_predictor.dataset TICKER --period 1Y
    ```
-   The `period` argument is positional and defaults to `max` if omitted.
+   The `period` can be passed with `--period` (shown above) or as a positional
+   argument for backward compatibility and defaults to `max` if omitted.
 4. **Generate plots**
    ```bash
    python -m sentimental_cap_predictor.plots TICKER

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -13,9 +13,10 @@
 ## Data Ingestion and Sentiment Analysis
 - Download price and news data for a ticker:
   ```bash
-  python -m sentimental_cap_predictor.dataset TICKER 1Y
+  python -m sentimental_cap_predictor.dataset TICKER --period 1Y
   ```
-  The `period` argument is positional and defaults to `max` if omitted.
+  The `period` can be supplied with `--period` or as a positional argument for
+  backward compatibility. It defaults to `max` when omitted.
 - Generate plots or other visualizations:
   ```bash
   python -m sentimental_cap_predictor.plots TICKER

--- a/src/sentimental_cap_predictor/dataset.py
+++ b/src/sentimental_cap_predictor/dataset.py
@@ -187,14 +187,29 @@ def main(
     ticker: str,
     period: Annotated[
         str,
-        typer.Argument(
-            help="Period for data collection (e.g., '1Y', '1M', '1W', or 'max')"
+        typer.Option(
+            "--period",
+            "-p",
+            help=(
+                "Period for data collection (e.g., '1Y', '1M', '1W', or 'max'). "
+                "Can also be provided positionally for backward compatibility."
+            ),
         ),
     ] = "max",
+    period_arg: Annotated[
+        str | None,
+        typer.Argument(
+            metavar="PERIOD",
+            help="Period for data collection (legacy positional form)",
+            show_default=False,
+        ),
+    ] = None,
     output_path: Optional[Path] = None,
     news_output_path: Optional[Path] = None,
     use_headless: bool = False,
 ) -> None:
+    if period_arg is not None:
+        period = period_arg
     logger.info(
         f"{Fore.YELLOW}Starting data collection for ticker: {ticker}.{Style.RESET_ALL}"
     )


### PR DESCRIPTION
## Summary
- allow specifying dataset period via `--period` flag while keeping old positional argument
- document `--period` usage in README and user manual

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/dataset.py README.md docs/user_manual.md`
- `PYTHONPATH=src pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory...)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8821e6c832b81649fb2415ba3ad