### PR TITLE
Add sandbox utilities for safe shell execution

### DIFF
--- a/src/sentimental_cap_predictor/agent/sandbox.py
+++ b/src/sentimental_cap_predictor/agent/sandbox.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from typing import Sequence
+
+from .dispatcher import DispatchResult
+
+# Allowed executables for safe_shell
+_ALLOWED_BINARIES = {
+    "python",
+    "pytest",
+    "ls",
+    "dir",
+    "cat",
+    "type",
+    "echo",
+    "nvidia-smi",
+    "pip",
+    "git",
+}
+
+
+def run_subprocess(args: Sequence[str], timeout: int = 60) -> subprocess.CompletedProcess[str]:
+    """Execute ``args`` in a restricted subprocess environment.
+
+    The subprocess receives no stdin, only a minimal environment, and its
+    combined stdout/stderr is captured and returned.
+    """
+
+    env = {"PATH": os.environ.get("PATH", "")}
+    if "PYTHONPATH" in os.environ:
+        env["PYTHONPATH"] = os.environ["PYTHONPATH"]
+
+    return subprocess.run(
+        list(args),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def safe_shell(cmd: str, timeout: int = 60) -> DispatchResult:
+    """Execute ``cmd`` using a restricted whitelist-based policy.
+
+    Parameters
+    ----------
+    cmd:
+        Command string to execute. Only simple commands invoking whitelisted
+        binaries without shell control operators are permitted.
+    timeout:
+        Maximum time in seconds the command is allowed to run.
+    """
+
+    if not cmd.strip():
+        return DispatchResult(ok=False, message="empty command")
+
+    forbidden = {"|", "&", ";", ">", "<"}
+    if any(token in cmd for token in forbidden):
+        return DispatchResult(ok=False, message="pipes and redirects are not allowed")
+
+    try:
+        args = shlex.split(cmd)
+    except Exception as exc:
+        return DispatchResult(ok=False, message=f"parse error: {exc}")
+
+    binary = os.path.basename(args[0])
+    if binary not in _ALLOWED_BINARIES:
+        return DispatchResult(ok=False, message=f"command '{binary}' is not allowed")
+
+    proc = run_subprocess(args, timeout=timeout)
+    output = proc.stdout.rstrip()
+    if proc.returncode != 0:
+        return DispatchResult(ok=False, message=output)
+    return DispatchResult(ok=True, message=output)

--- a/tests/test_agent_sandbox.py
+++ b/tests/test_agent_sandbox.py
@@ -1,0 +1,25 @@
+from sentimental_cap_predictor.agent.sandbox import run_subprocess, safe_shell
+
+
+def test_run_subprocess_echo():
+    proc = run_subprocess(["echo", "hi"])
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == "hi"
+
+
+def test_safe_shell_allows_echo():
+    res = safe_shell("echo hello")
+    assert res.ok
+    assert res.message.strip() == "hello"
+
+
+def test_safe_shell_rejects_unknown_binary():
+    res = safe_shell("sleep 0")
+    assert not res.ok
+    assert "not allowed" in res.message
+
+
+def test_safe_shell_rejects_semicolons():
+    res = safe_shell("echo hi; ls")
+    assert not res.ok
+    assert "not allowed" in res.message or "pipes and redirects" in res.message


### PR DESCRIPTION
## Summary
- Add sandbox helper to run subprocesses with no stdin and minimal environment
- Provide `safe_shell` that whitelists basic binaries and blocks pipes/redirects
- Cover sandbox helpers with unit tests

## Testing
- `pytest tests/test_agent_sandbox.py tests/test_agent_dispatcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8fa07a910832b88c276bb5bac3ad3