### PR TITLE
Add stub coding agent and disabled code implementation command

### DIFF
--- a/src/sentimental_cap_predictor/agent/coding_agent.py
+++ b/src/sentimental_cap_predictor/agent/coding_agent.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Placeholder coding agent utilities.
+
+This module sketches out interfaces for generating and applying code changes.
+The implementations are deliberately minimal and do not modify the repository.
+"""
+
+from .dispatcher import DispatchResult
+
+
+def propose_changes(objective: str, context: str) -> str:
+    """Return a placeholder patch for ``objective`` given ``context``.
+
+    Parameters
+    ----------
+    objective:
+        High level description of the requested change.
+    context:
+        Supplementary information or source content to consider.
+    """
+
+    return (
+        "---\n"
+        f"# objective: {objective}\n"
+        f"# context: {context}\n"
+        "+++\n"
+    )
+
+
+def apply_changes(patch: str) -> DispatchResult:
+    """Stub handler that pretends to apply ``patch`` to the codebase.
+
+    The operation is intentionally disabled. The function merely returns a
+    :class:`DispatchResult` communicating that the command is unavailable.
+    """
+
+    return DispatchResult(ok=False, message="code.implement disabled")

--- a/src/sentimental_cap_predictor/agent/command_registry.py
+++ b/src/sentimental_cap_predictor/agent/command_registry.py
@@ -66,6 +66,7 @@ def promote_model(src: str, dst: str) -> str:
 
 def get_registry() -> Dict[str, Command]:
     """Return mapping of command names to :class:`Command` entries."""
+    from sentimental_cap_predictor.agent import coding_agent
 
     return {
         "data.ingest": Command(
@@ -162,6 +163,13 @@ def get_registry() -> Dict[str, Command]:
             handler=system_status,
             summary="Report basic system information",
             params_schema={},
+        ),
+        "code.implement": Command(
+            name="code.implement",
+            handler=coding_agent.apply_changes,
+            summary="Apply a code patch generated elsewhere",
+            params_schema={"patch": "str"},
+            dangerous=True,
         ),
         "shell.run": Command(
             name="shell.run",


### PR DESCRIPTION
## Summary
- stub out coding agent with propose/apply interfaces
- register `code.implement` command that returns disabled result

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8faeeeac0832bbb864b33866c0b0b