### PR TITLE
Add parser, dispatcher, and shell safety tests

### DIFF
--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,54 @@
+from sentimental_cap_predictor.agent import command_registry
+from sentimental_cap_predictor.agent import dispatcher as dispatcher_module
+from sentimental_cap_predictor.agent.dispatcher import DispatchResult
+
+
+def test_dispatch_uses_handler_and_structures_result(monkeypatch):
+    calls: list[int] = []
+
+    def handler(x: int) -> dict[str, object]:
+        calls.append(x)
+        return {
+            "summary": "done",
+            "metrics": {"x": x},
+            "artifacts": ["out.txt"],
+        }
+
+    cmd = command_registry.Command(
+        name="dummy",
+        handler=handler,
+        summary="",
+        params_schema={"x": "int"},
+    )
+    monkeypatch.setattr(
+        dispatcher_module,
+        "get_registry",
+        lambda: {"dummy": cmd},
+    )
+
+    res = dispatcher_module.dispatch({"command": "dummy", "x": 5})
+    assert calls == [5]
+    assert res == DispatchResult(
+        ok=True, message="done", metrics={"x": 5}, artifacts=["out.txt"]
+    )
+
+
+def test_dispatch_validation_failure(monkeypatch):
+    def handler(x: int) -> None:
+        return None
+
+    cmd = command_registry.Command(
+        name="dummy",
+        handler=handler,
+        summary="",
+        params_schema={"x": "int"},
+    )
+    monkeypatch.setattr(
+        dispatcher_module,
+        "get_registry",
+        lambda: {"dummy": cmd},
+    )
+
+    res = dispatcher_module.dispatch({"command": "dummy", "x": "a"})
+    assert not res.ok
+    assert "x" in res.message

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,30 @@
+import pytest
+
+from sentimental_cap_predictor.agent.nl_parser import parse
+
+
+@pytest.mark.parametrize(
+    "text,action,params",
+    [
+        (
+            "ingest SPY 1y 1d",
+            "data.ingest",
+            {"ticker": "SPY", "period": "1y", "interval": "1d"},
+        ),
+        ("train model AAPL", "model.train_eval", {"ticker": "AAPL"}),
+        ("compare 1 2", "experiments.compare", {"first": 1, "second": 2}),
+        ("system status", "sys.status", {}),
+    ],
+)
+def test_regex_intent_mapping(
+    text: str, action: str, params: dict[str, object]
+) -> None:
+    intent = parse(text)
+    assert intent.action == action
+    assert intent.params == params
+
+
+def test_requires_confirmation() -> None:
+    intent = parse("promote foo bar")
+    assert intent.action == "model.promote"
+    assert intent.requires_confirmation

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,27 @@
+from sentimental_cap_predictor.agent.sandbox import safe_shell
+
+
+def test_safe_shell_whitelisted_binary():
+    res = safe_shell("echo hello")
+    assert res.ok
+    assert res.message.strip() == "hello"
+
+
+def test_safe_shell_rejects_semicolon():
+    res = safe_shell("echo hi; ls")
+    assert not res.ok
+
+
+def test_safe_shell_rejects_double_ampersand():
+    res = safe_shell("echo hi && ls")
+    assert not res.ok
+
+
+def test_safe_shell_rejects_pipe():
+    res = safe_shell("echo hi | grep hi")
+    assert not res.ok
+
+
+def test_safe_shell_rejects_unknown_binary():
+    res = safe_shell("foobar")
+    assert not res.ok


### PR DESCRIPTION
## Summary
- add parser tests covering regex phrases and confirmation flag
- verify dispatcher uses dummy handlers and validates params
- ensure sandbox safe_shell only allows whitelisted commands and rejects dangerous operators

## Testing
- `pre-commit run --files tests/test_dispatcher.py tests/test_parser.py tests/test_safety.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a901db32e8832b938fce19778d3f14