### PR TITLE
feat: add help alias and examples

### DIFF
--- a/README_CHATBOT.md
+++ b/README_CHATBOT.md
@@ -11,8 +11,8 @@ Run the bot using the module path:
 python -m sentimental_cap_predictor.chatbot
 ```
 
-This starts an interactive prompt. Type `help` to see available commands or
-`exit` to leave the session.
+This starts an interactive prompt. Type `help` or `?` to see available
+commands or `exit` to leave the session.
 
 ## Confirmation & Safety
 

--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -94,9 +94,7 @@ def _print_help(
     for name, entry in registry.items():
         summary = _get_attr(entry, "summary", "")
         examples = _get_attr(entry, "examples", []) or []
-        line = f"- {name}"
-        if summary:
-            line += f": {summary}"
+        line = f"- {summary}" if summary else f"- {name}"
         echo_fn(line)
         for ex in examples:
             echo_fn(f"  e.g. {ex}")
@@ -132,9 +130,10 @@ def chat_loop(
 
     while True:
         prompt = prompt_fn("prompt")
-        if prompt.strip().lower() in {"exit", "quit"}:
+        normalized = prompt.strip().lower()
+        if normalized in {"exit", "quit"}:
             break
-        if prompt.strip().lower() == "help":
+        if normalized in {"help", "?"}:
             _print_help(nl_parser, echo_fn)
             continue
         try:

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,4 +1,5 @@
 import types
+import pytest
 
 from sentimental_cap_predictor.chatbot import chat_loop
 
@@ -41,12 +42,13 @@ def iter_inputs(*items: str) -> types.FunctionType:
     return _next
 
 
-def test_help_lists_registry(capsys):
+@pytest.mark.parametrize("trigger", ["help", "?"])
+def test_help_lists_registry(trigger, capsys):
     parser = DummyParser()
     dispatcher = DummyDispatcher()
-    chat_loop(parser, dispatcher, prompt_fn=iter_inputs("help", "exit"))
+    chat_loop(parser, dispatcher, prompt_fn=iter_inputs(trigger, "exit"))
     out = capsys.readouterr().out
-    assert "foo" in out and "do foo" in out and "foo bar" in out
+    assert "do foo" in out and "foo bar" in out
 
 
 def test_dispatch_and_prints(capsys):


### PR DESCRIPTION
## Summary
- support `?` shorthand for chatbot help
- show command summaries and sample phrases from the registry
- document the new help shortcut

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9045399b4832b85f0827285131d34