### PR TITLE
Support chained commands in chatbot

### DIFF
--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -81,6 +81,20 @@ def test_confirmation(monkeypatch, capsys):
     assert not dispatcher.dispatched
 
 
+def test_chained_dispatch(capsys):
+    class ChainParser(DummyParser):
+        def parse(self, prompt: str) -> list[dict[str, object]]:  # type: ignore[override]
+            return [{"command": "a"}, {"command": "b"}]
+
+    parser = ChainParser()
+    dispatcher = DummyDispatcher()
+    chat_loop(parser, dispatcher, prompt_fn=iter_inputs("multi", "exit"))
+    out = capsys.readouterr().out
+    assert "Step 1" in out and "Step 2" in out
+    assert out.count("SUCCESS: ok") == 2
+    assert len(dispatcher.dispatched) == 2
+
+
 def test_hide_traceback(capsys):
     class ErrorParser(DummyParser):
         def parse(self, prompt: str) -> dict[str, object]:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -28,3 +28,19 @@ def test_requires_confirmation() -> None:
     intent = parse("promote foo bar")
     assert intent.action == "model.promote"
     assert intent.requires_confirmation
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "ingest SPY 1y 1d; train model SPY",
+        "ingest SPY 1y 1d and then train model SPY",
+    ],
+)
+def test_chained_commands(text: str) -> None:
+    intents = parse(text)
+    assert isinstance(intents, list)
+    assert [i.action for i in intents] == [
+        "data.ingest",
+        "model.train_eval",
+    ]


### PR DESCRIPTION
## Summary
- Allow `nl_parser.parse` to split prompts into chained commands and return multiple intents when separated by `;` or `and then`
- Update chatbot loop to sequentially execute multiple intents and print step summaries
- Test chained command parsing and multi-step dispatch

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a905719c2c832baea6a6ab9112197c