### PR TITLE
Fix chatbot import paths for dispatcher and parser

### DIFF
--- a/src/sentimental_cap_predictor/__init__.py
+++ b/src/sentimental_cap_predictor/__init__.py
@@ -1,1 +1,5 @@
+from .agent import dispatcher, nl_parser
+
+__all__ = ["dispatcher", "nl_parser"]
+
 from . import config  # noqa: F401

--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -180,8 +180,8 @@ def chat(
     """
 
     try:
-        from . import dispatcher as default_dispatcher  # type: ignore
-        from . import nl_parser as default_parser  # type: ignore
+        from .agent import dispatcher as default_dispatcher
+        from .agent import nl_parser as default_parser
     except Exception as exc:  # pragma: no cover - import failure
         typer.echo(f"Unable to import parser/dispatcher: {exc}")
         return


### PR DESCRIPTION
## Summary
- import dispatcher and parser from agent module in chatbot
- expose dispatcher and nl_parser in package __init__ for broader access

## Testing
- `PYTHONPATH=src python -m sentimental_cap_predictor.chatbot --help`
- `PYTHONPATH=src pytest` *(fails: Sandbox terminated unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68a9157a81d4832b8e487f5c07f9f9a5