### PR TITLE
Handle dispatcher failures in chatbot

### DIFF
--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -79,6 +79,17 @@ def _print_result(
             echo_fn(f"  {art}")
 
 
+def _print_failure(
+    result: Any,
+    echo_fn: Callable[[str], None] = typer.echo,
+) -> None:
+    """Print the failure message from ``result``."""
+
+    message = _get_attr(result, "message", "")
+    if message:
+        echo_fn(message)
+
+
 def _print_help(
     nl_parser: Any,
     echo_fn: Callable[[str], None] = typer.echo,
@@ -155,9 +166,13 @@ def chat_loop(
             except Exception as exc:  # pragma: no cover - dispatcher failure
                 _handle_error(exc, debug, echo_fn)
                 continue
+            ok = _get_attr(result, "ok", True)
             if multi:
                 echo_fn(f"Step {idx}:")
-            _print_result(result, echo_fn)
+            if ok:
+                _print_result(result, echo_fn)
+            else:
+                _print_failure(result, echo_fn)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- show failure messages from dispatcher via `_print_failure`
- handle `ok=False` results in `chat_loop`
- add test for friendly unknown command response

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot.py tests/test_chatbot.py`
- `pytest` *(fails: Sandbox terminated unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68a91ab6dd58832bb2e63723eb2abf5e