### PR TITLE
refactor: rename intent action to command

### DIFF
--- a/src/sentimental_cap_predictor/agent/nl_parser.py
+++ b/src/sentimental_cap_predictor/agent/nl_parser.py
@@ -13,7 +13,7 @@ class Intent:
 
     Attributes
     ----------
-    action:
+    command:
         Name of the command to execute. ``None`` if no command could be
         inferred.
     params:
@@ -24,10 +24,22 @@ class Intent:
         Heuristic confidence score between 0 and 1.
     """
 
-    action: str | None
+    command: str | None
     params: Dict[str, Any] = field(default_factory=dict)
     requires_confirmation: bool = False
     confidence: float = 0.0
+
+    # Backwards compatibility -------------------------------------------------
+    # ``action`` was the original field name. Provide a property so existing
+    # code that still accesses ``intent.action`` continues to work without
+    # modification.
+    @property
+    def action(self) -> str | None:  # pragma: no cover - legacy support
+        return self.command
+
+    @action.setter  # pragma: no cover - legacy support
+    def action(self, value: str | None) -> None:
+        self.command = value
 
 
 def parse(
@@ -253,7 +265,7 @@ def _fallback_heuristic(text: str) -> Intent:
     candidate = Path(text)
     if candidate.exists():
         return Intent("file.read", {"path": text}, confidence=0.2)
-    return Intent(action=None, params={"text": text}, confidence=0.0)
+    return Intent(command=None, params={"text": text}, confidence=0.0)
 
 
 __all__ = ["Intent", "parse"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,7 @@ from sentimental_cap_predictor.agent.nl_parser import parse
 
 
 @pytest.mark.parametrize(
-    "text,action,params",
+    "text,command,params",
     [
         (
             "ingest SPY 1y 1d",
@@ -17,16 +17,16 @@ from sentimental_cap_predictor.agent.nl_parser import parse
     ],
 )
 def test_regex_intent_mapping(
-    text: str, action: str, params: dict[str, object]
+    text: str, command: str, params: dict[str, object]
 ) -> None:
     intent = parse(text)
-    assert intent.action == action
+    assert intent.command == command
     assert intent.params == params
 
 
 def test_requires_confirmation() -> None:
     intent = parse("promote foo bar")
-    assert intent.action == "model.promote"
+    assert intent.command == "model.promote"
     assert intent.requires_confirmation
 
 
@@ -40,7 +40,7 @@ def test_requires_confirmation() -> None:
 def test_chained_commands(text: str) -> None:
     intents = parse(text)
     assert isinstance(intents, list)
-    assert [i.action for i in intents] == [
+    assert [i.command for i in intents] == [
         "data.ingest",
         "model.train_eval",
     ]


### PR DESCRIPTION
## Summary
- switch `Intent.action` to `Intent.command` with backward compatibility
- update parser tests to use the new `command` attribute

## Testing
- `pytest`
- `pytest tests/test_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a91c086718832ba654049d99b121d1