### PR TITLE
Handle missing summaries in chatbot results

### DIFF
--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -65,6 +65,10 @@ def _print_result(
     summary = _get_attr(result, "summary")
     if summary:
         echo_fn(f"SUCCESS: {summary}")
+    else:
+        message = _get_attr(result, "message")
+        if message:
+            echo_fn(f"SUCCESS: {message}")
 
     metrics = _get_attr(result, "metrics", {}) or {}
     if metrics:


### PR DESCRIPTION
## Summary
- Fallback to printing dispatcher message when summary is absent in chatbot results
- Add tests for dispatcher outputs without summary and failing dispatches

## Testing
- `pytest tests/test_chatbot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a91daf02e0832ba0c0a98a6c043071