### PR TITLE
Add help fallback for unrecognized chatbot commands

### DIFF
--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -156,8 +156,15 @@ def chat_loop(
         except Exception as exc:  # pragma: no cover - parser failure
             _handle_error(exc, debug, echo_fn)
             continue
-
-        task_list = tasks if isinstance(tasks, list) else [tasks]
+        task_list = (
+            tasks
+            if isinstance(tasks, list)
+            else ([tasks] if tasks is not None else [])
+        )
+        if not task_list or all(not _get_attr(t, "command") for t in task_list):
+            echo_fn("Unknown command, type `help` to see options.")
+            _print_help(nl_parser, echo_fn)
+            continue
         multi = len(task_list) > 1
 
         for idx, task in enumerate(task_list, 1):

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -162,6 +162,20 @@ def test_unknown_command_prints_message(capsys):
     assert "SUCCESS" not in out
 
 
+def test_unknown_text_provides_guidance(capsys):
+    class NoCommandParser(DummyParser):
+        def parse(self, prompt: str) -> dict[str, object]:  # type: ignore[override]
+            return {}
+
+    parser = NoCommandParser()
+    dispatcher = DummyDispatcher()
+    chat_loop(parser, dispatcher, prompt_fn=iter_inputs("unknown text", "exit"))
+    out = capsys.readouterr().out
+    assert "Unknown command" in out
+    assert "do foo" in out
+    assert not dispatcher.dispatched
+
+
 def test_failed_dispatch_prints_message(capsys):
     class FailDispatcher(DummyDispatcher):
         def dispatch(self, task: object) -> dict[str, object]:  # type: ignore[override]


### PR DESCRIPTION
## Summary
- teach `chat_loop` to hint and show available commands when the parser returns no command
- cover fallback behavior with a new chatbot unit test

## Testing
- `pytest tests/test_chatbot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a91e708000832bac49cb11e8b4b4d3