### PR TITLE
Enhance chatbot parsing and sandbox safety

### DIFF
--- a/README_CHATBOT.md
+++ b/README_CHATBOT.md
@@ -30,7 +30,7 @@ The natural language parser supports several shortcuts:
 - `train model AAPL` – fit baseline models for a ticker
 - `compare 1 2` – compare two experiment runs
 - `system status` – report Python and platform versions
-- `shell ls` – run a shell command (requires confirmation)
+- `shell ls` – run a shell command (requires confirmation, only whitelisted binaries are allowed)
 
 ## Extending With New Commands
 

--- a/src/sentimental_cap_predictor/agent/command_registry.py
+++ b/src/sentimental_cap_predictor/agent/command_registry.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Sequence
 import platform
-import subprocess
 import sys
 
 import pytest
@@ -48,10 +47,6 @@ def system_status() -> Dict[str, str]:
     return {"python": sys.version, "platform": platform.platform()}
 
 
-def run_shell(cmd: str) -> subprocess.CompletedProcess[str]:
-    """Execute ``cmd`` in the system shell."""
-
-    return subprocess.run(cmd, shell=True, capture_output=True, text=True)
 
 
 def promote_model(src: str, dst: str, dry_run: bool | None = False) -> Dict[str, Any]:
@@ -89,6 +84,7 @@ def promote_model(src: str, dst: str, dry_run: bool | None = False) -> Dict[str,
 def get_registry() -> Dict[str, Command]:
     """Return mapping of command names to :class:`Command` entries."""
     from sentimental_cap_predictor.agent import coding_agent
+    from .sandbox import safe_shell
 
     return {
         "data.ingest": Command(
@@ -195,8 +191,8 @@ def get_registry() -> Dict[str, Command]:
         ),
         "shell.run": Command(
             name="shell.run",
-            handler=run_shell,
-            summary="Execute a shell command",
+            handler=safe_shell,
+            summary="Execute a shell command in a restricted sandbox",
             params_schema={"cmd": "str"},
             dangerous=True,
         ),

--- a/src/sentimental_cap_predictor/agent/dispatcher.py
+++ b/src/sentimental_cap_predictor/agent/dispatcher.py
@@ -130,6 +130,7 @@ def dispatch(intent: Mapping[str, Any] | Any) -> DispatchResult:
     message = _get_attr(output, "summary") or _get_attr(output, "message", "")
     metrics_obj = _get_attr(output, "metrics", {}) or {}
     artifacts_obj = _get_attr(output, "artifacts", []) or []
+    ok_flag = _get_attr(output, "ok", True)
 
     if isinstance(metrics_obj, Mapping):
         metrics = dict(metrics_obj)
@@ -149,8 +150,13 @@ def dispatch(intent: Mapping[str, Any] | Any) -> DispatchResult:
         elif output is not None:
             message = str(output)
 
+    try:
+        ok = bool(ok_flag)
+    except Exception:  # pragma: no cover - non-boolean ok
+        ok = True
+
     return DispatchResult(
-        ok=True,
+        ok=ok,
         message=message,
         artifacts=artifacts,
         metrics=metrics,

--- a/tests/test_agent_dispatcher.py
+++ b/tests/test_agent_dispatcher.py
@@ -41,3 +41,9 @@ def test_dispatch_custom_command(monkeypatch):
     assert res.message == "done"
     assert res.metrics == {"acc": 1}
     assert res.artifacts == ["out.txt"]
+
+
+def test_dispatch_shell_respects_sandbox():
+    res = dispatch({"command": "shell.run", "cmd": "sleep 0"})
+    assert not res.ok
+    assert "not allowed" in res.message

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,6 +35,7 @@ def test_requires_confirmation() -> None:
     [
         "ingest SPY 1y 1d; train model SPY",
         "ingest SPY 1y 1d and then train model SPY",
+        "ingest SPY 1y 1d and train model SPY",
     ],
 )
 def test_chained_commands(text: str) -> None:


### PR DESCRIPTION
## Summary
- allow natural language prompts to chain multiple commands with simple "and" separators and support retraining phrasing
- propagate handler success flags in dispatcher and route `shell.run` through sandboxed execution
- document shell whitelist in chatbot README and add tests for new behaviours

## Testing
- `pytest tests/test_parser.py tests/test_agent_dispatcher.py tests/test_agent_sandbox.py tests/test_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a920a4de0c832ba767352ab5742957