### PR TITLE
Expose NL parser registry and test chatbot help

### DIFF
--- a/src/sentimental_cap_predictor/agent/nl_parser.py
+++ b/src/sentimental_cap_predictor/agent/nl_parser.py
@@ -6,6 +6,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 
+from .command_registry import get_registry
+
+# Registry ------------------------------------------------------------------
+registry = get_registry()
+
 
 @dataclass
 class Intent:
@@ -277,4 +282,4 @@ def _fallback_heuristic(text: str) -> Intent:
     return Intent(command=None, params={"text": text}, confidence=0.0)
 
 
-__all__ = ["Intent", "parse"]
+__all__ = ["Intent", "parse", "registry"]

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -2,7 +2,7 @@ import types
 
 import pytest
 
-from sentimental_cap_predictor.chatbot import chat_loop
+from sentimental_cap_predictor.chatbot import _print_help, chat_loop
 
 
 class DummyParser:
@@ -50,6 +50,15 @@ def test_help_lists_registry(trigger, capsys):
     chat_loop(parser, dispatcher, prompt_fn=iter_inputs(trigger, "exit"))
     out = capsys.readouterr().out
     assert "do foo" in out and "foo bar" in out
+
+
+def test_print_help_lists_real_commands(capsys):
+    from sentimental_cap_predictor.agent import nl_parser as real_parser
+
+    _print_help(real_parser)
+    out = capsys.readouterr().out
+    assert "Available commands:" in out
+    assert "Download and prepare price data" in out
 
 
 def test_dispatch_and_prints(capsys):


### PR DESCRIPTION
## Summary
- expose command registry via `nl_parser.registry` so chatbot help can list real commands
- test `_print_help` with real parser to ensure command summaries are shown

## Testing
- `pytest -q` *(fails: Sandbox terminated unexpectedly in tests/test_sandbox.py::test_dangerous_builtin_not_available and tests/test_sandbox.py::test_run_code_returns_environment)*

------
https://chatgpt.com/codex/tasks/task_e_68accece174c832b9b2b4cf0e355986c