### PR TITLE
Handle help question phrases in chatbot

### DIFF
--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -148,7 +148,12 @@ def chat_loop(
         normalized = prompt.strip().lower()
         if normalized in {"exit", "quit"}:
             break
-        if normalized in {"help", "?"}:
+        normalized_no_q = normalized.rstrip("?")
+        help_phrases = {"what can you do", "what actions can you take"}
+        if (
+            normalized in {"help", "?"}
+            or any(phrase in normalized_no_q for phrase in help_phrases)
+        ):
             _print_help(nl_parser, echo_fn)
             continue
         try:

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -52,6 +52,19 @@ def test_help_lists_registry(trigger, capsys):
     assert "do foo" in out and "foo bar" in out
 
 
+@pytest.mark.parametrize(
+    "trigger",
+    ["what can you do?", "what actions can you take?", "hey, what can you do?"],
+)
+def test_question_triggers_help(trigger, capsys):
+    parser = DummyParser()
+    dispatcher = DummyDispatcher()
+    chat_loop(parser, dispatcher, prompt_fn=iter_inputs(trigger, "exit"))
+    out = capsys.readouterr().out
+    assert "do foo" in out and "foo bar" in out
+    assert "Unknown command" not in out
+
+
 def test_dispatch_and_prints(capsys):
     parser = DummyParser()
     dispatcher = DummyDispatcher()
@@ -155,7 +168,7 @@ def test_unknown_command_prints_message(capsys):
     chat_loop(
         parser,
         dispatcher,
-        prompt_fn=iter_inputs("hey, what can you do?", "exit"),
+        prompt_fn=iter_inputs("run", "exit"),
     )
     out = capsys.readouterr().out
     assert "Unknown command, type `help` to see options." in out


### PR DESCRIPTION
## Summary
- Teach `chat_loop` to treat phrases like "what can you do" or "what actions can you take" as help requests
- Add tests ensuring these questions display help text without an unknown command message
- Update existing dispatcher failure test to use a neutral prompt

## Testing
- `pytest tests/test_chatbot.py -q`
- `pytest tests/test_experiment_chatbot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acced08a44832b81fa21c85f5e720d