### PR TITLE
Improve NL parser resilience to polite prefixes

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,6 +14,11 @@ from sentimental_cap_predictor.agent.nl_parser import parse
         ("train model AAPL", "model.train_eval", {"ticker": "AAPL"}),
         ("compare 1 2", "experiments.compare", {"first": 1, "second": 2}),
         ("system status", "sys.status", {}),
+        (
+            "Hey, can you run the full pipeline?",
+            "pipeline.run_daily",
+            {},
+        ),
     ],
 )
 def test_regex_intent_mapping(


### PR DESCRIPTION
## Summary
- Strip leading greetings and polite phrases from natural language input before parsing
- Switch to `re.search` and broaden regex to allow optional words (e.g. `run.*pipeline`)
- Add parser test for "Hey, can you run the full pipeline?"

## Testing
- `pytest tests/test_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68acd5e8acc0832b85212be6927ccdbf