### PR TITLE
Add FastAPI command dispatch UI and uvicorn entry point

### DIFF
--- a/scripts/run_ui.py
+++ b/scripts/run_ui.py
@@ -1,0 +1,13 @@
+"""Run the FastAPI UI using Uvicorn."""
+
+from sentimental_cap_predictor.ui.api import app
+import uvicorn
+
+
+def main() -> None:
+    """Launch the FastAPI application."""
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sentimental_cap_predictor/ui/__init__.py
+++ b/src/sentimental_cap_predictor/ui/__init__.py
@@ -1,0 +1,5 @@
+"""UI package exposing FastAPI app."""
+
+from .api import app
+
+__all__ = ["app"]

--- a/src/sentimental_cap_predictor/ui/api.py
+++ b/src/sentimental_cap_predictor/ui/api.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""FastAPI application exposing command dispatch endpoints."""
+
+from typing import Any, Dict
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from sentimental_cap_predictor.agent import command_registry, dispatcher
+
+app = FastAPI()
+
+
+class RunRequest(BaseModel):
+    """Request body for the run endpoint."""
+
+    command: str
+    params: Dict[str, Any] | None = None
+
+
+@app.get("/commands")
+def list_commands() -> Dict[str, Any]:
+    """Return available command summaries and example payloads."""
+
+    registry = command_registry.get_registry()
+    commands: Dict[str, Any] = {}
+    for name, cmd in registry.items():
+        example_params = {k: f"<{v}>" for k, v in (cmd.params_schema or {}).items()}
+        commands[name] = {
+            "summary": cmd.summary,
+            "example": {"command": name, "params": example_params},
+        }
+    return commands
+
+
+@app.post("/run")
+def run_command(request: RunRequest) -> Dict[str, Any]:
+    """Execute the requested command via the dispatcher."""
+
+    intent = {"command": request.command, "params": request.params or {}}
+    result = dispatcher.dispatch(intent)
+    return {
+        "ok": result.ok,
+        "message": result.message,
+        "artifacts": result.artifacts,
+        "metrics": result.metrics,
+    }


### PR DESCRIPTION
## Summary
- expose command registry and dispatch through a FastAPI app
- add `/commands` and `/run` endpoints
- provide `scripts/run_ui.py` to serve the API via uvicorn

## Testing
- `pytest` *(fails: Sandbox terminated unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68ace29680c4832b9ab7fab5f8f419e8