### PR TITLE
Add reasoning context to dispatch results and UI

### DIFF
--- a/src/sentimental_cap_predictor/agent/command_registry.py
+++ b/src/sentimental_cap_predictor/agent/command_registry.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import platform
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Sequence
 import platform
 import sys
+import json
 
 import pytest
 
@@ -46,6 +47,17 @@ def system_status() -> Dict[str, str]:
     """Return basic information about the Python runtime and platform."""
 
     return {"python": sys.version, "platform": platform.platform()}
+
+
+def ideas_generate_with_reasoning(topic: str, model_id: str, n: int) -> Dict[str, Any]:
+    """Wrapper around :func:`idea_generator.generate_ideas` including context."""
+
+    ideas = idea_generator.generate_ideas(topic, model_id=model_id, n=n)
+    return {
+        "message": json.dumps([asdict(i) for i in ideas], indent=2),
+        "metrics": {"num_ideas": len(ideas)},
+        "reasoning": f"Generated {len(ideas)} ideas about {topic} using model {model_id}",
+    }
 
 
 
@@ -148,7 +160,7 @@ def get_registry() -> Dict[str, Command]:
         ),
         "ideas.generate": Command(
             name="ideas.generate",
-            handler=idea_generator.generate_ideas,
+            handler=ideas_generate_with_reasoning,
             summary="Generate trading ideas using a local model",
             params_schema={"topic": "str", "model_id": "str", "n": "int"},
         ),

--- a/src/sentimental_cap_predictor/agent/dispatcher.py
+++ b/src/sentimental_cap_predictor/agent/dispatcher.py
@@ -33,6 +33,7 @@ class DispatchResult:
     message: str = ""
     artifacts: list[str] = field(default_factory=list)
     metrics: dict[str, Any] = field(default_factory=dict)
+    reasoning: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +131,7 @@ def dispatch(intent: Mapping[str, Any] | Any) -> DispatchResult:
     message = _get_attr(output, "summary") or _get_attr(output, "message", "")
     metrics_obj = _get_attr(output, "metrics", {}) or {}
     artifacts_obj = _get_attr(output, "artifacts", []) or []
+    reasoning = _get_attr(output, "reasoning", "")
     ok_flag = _get_attr(output, "ok", True)
 
     if isinstance(metrics_obj, Mapping):
@@ -160,4 +162,5 @@ def dispatch(intent: Mapping[str, Any] | Any) -> DispatchResult:
         message=message,
         artifacts=artifacts,
         metrics=metrics,
+        reasoning=reasoning,
     )

--- a/src/sentimental_cap_predictor/flows/daily_pipeline.py
+++ b/src/sentimental_cap_predictor/flows/daily_pipeline.py
@@ -96,6 +96,17 @@ def run(
     logger.info("Summary report written to %s", path)
     typer.echo(f"Summary report saved to {path}")
 
+    reasoning = (
+        f"RMSE {rmse}, backtest return {backtest_return} with windows "
+        f"{opt.short_window}/{opt.long_window}"
+    )
+    return {
+        "summary": f"Pipeline run complete for {ticker}",
+        "artifacts": [str(path)],
+        "metrics": {"rmse": rmse, "backtest_return": backtest_return},
+        "reasoning": reasoning,
+    }
+
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
     app()

--- a/src/sentimental_cap_predictor/ui/api.py
+++ b/src/sentimental_cap_predictor/ui/api.py
@@ -47,6 +47,7 @@ def run_command(request: RunRequest) -> Dict[str, Any]:
         "message": result.message,
         "artifacts": result.artifacts,
         "metrics": result.metrics,
+        "reasoning": result.reasoning,
     }
 
 

--- a/src/sentimental_cap_predictor/ui/static/index.html
+++ b/src/sentimental_cap_predictor/ui/static/index.html
@@ -74,6 +74,15 @@
         result.appendChild(p);
       }
 
+      if (data.reasoning) {
+        const rTitle = document.createElement('h3');
+        rTitle.textContent = 'Reasoning';
+        result.appendChild(rTitle);
+        const p = document.createElement('p');
+        p.textContent = data.reasoning;
+        result.appendChild(p);
+      }
+
       if (data.metrics) {
         const mTitle = document.createElement('h3');
         mTitle.textContent = 'Metrics';

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -29,7 +29,11 @@ def test_dispatch_uses_handler_and_structures_result(monkeypatch):
     res = dispatcher_module.dispatch({"command": "dummy", "x": 5})
     assert calls == [5]
     assert res == DispatchResult(
-        ok=True, message="done", metrics={"x": 5}, artifacts=["out.txt"]
+        ok=True,
+        message="done",
+        metrics={"x": 5},
+        artifacts=["out.txt"],
+        reasoning="",
     )
 
 


### PR DESCRIPTION
## Summary
- extend DispatchResult with `reasoning` field
- populate reasoning from idea generation and daily pipeline handlers
- expose reasoning in API and web UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acee6151bc832ba141354b2cd67992