### PR TITLE
Handle meta-intents and add thinking indicator to chatbot

### DIFF
--- a/src/sentimental_cap_predictor/chatbot_nlu/__init__.py
+++ b/src/sentimental_cap_predictor/chatbot_nlu/__init__.py
@@ -1,5 +1,50 @@
 """Helpers for Qwen-powered intent parsing."""
 
-from . import qwen_intent
+from pathlib import Path
 
-__all__ = ["qwen_intent"]
+from . import qwen_intent
+from .dispatcher import Dispatcher
+from .io_types import Argument, DispatchDecision, NLUResult, Resolution
+from .ontology import Ontology
+from .policy import Policy
+from .reasoner import Reasoner
+from types import SimpleNamespace
+
+_ONT_PATH = Path(__file__).with_name("intents.yaml")
+_ONTOLOGY = Ontology(_ONT_PATH)
+_POLICY = Policy(_ONTOLOGY)
+_DISPATCHER = Dispatcher()
+_REASONER = Reasoner(_ONTOLOGY)
+_engine = SimpleNamespace(predict=qwen_intent.predict)
+
+
+def parse(utterance: str, ctx: dict) -> NLUResult:
+    data = _engine.predict(utterance)
+    if isinstance(data, NLUResult):
+        return data
+    intent = data.get("intent")
+    slots = data.get("slots", {}) or {}
+    required = _ONTOLOGY.required_slots(intent) if intent else []
+    missing = [s for s in required if s not in slots]
+    return NLUResult(intent=intent, scores=None, slots=slots, missing_slots=missing)
+
+
+def resolve(nlu: NLUResult, ctx: dict) -> Resolution:
+    return _POLICY.resolve(nlu, ctx)
+
+
+def dispatch(res: Resolution, ctx: dict) -> DispatchDecision:
+    return _DISPATCHER.dispatch(res, ctx)
+
+
+def explain(dec: DispatchDecision, nlu: NLUResult, ctx: dict) -> Argument:
+    return _REASONER.explain(dec, nlu, ctx)
+
+
+__all__ = [
+    "parse",
+    "resolve",
+    "dispatch",
+    "explain",
+    "qwen_intent",
+]

--- a/src/sentimental_cap_predictor/chatbot_nlu/nlu.py
+++ b/src/sentimental_cap_predictor/chatbot_nlu/nlu.py
@@ -29,6 +29,9 @@ class NLUEngine:
         labels: List[str] = []
         with examples_path.open() as fh:
             for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
                 obj = json.loads(line)
                 intent = obj["intent"]
                 if intent == "AMBIGUOUS":


### PR DESCRIPTION
## Summary
- Detect common greetings and help queries before invoking Qwen and dispatch a reply immediately
- Show a temporary "Thinking..." message while waiting for Qwen intent prediction
- Expose NLU parse/resolve/dispatch/explain helpers and make seed data loader resilient to blank lines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad16a592f8832bab2457fdc506234e