### PR TITLE
Use fallback when Qwen intent prediction fails

### DIFF
--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -194,12 +194,15 @@ def dispatch(intent: str, slots: Dict[str, Any]) -> str:
 
 
 def _predict_intent(text: str) -> Dict[str, Any]:
-    # Try Qwen NLU; if not wired yet, use fallback so commands still work
+    """Predict intent using the Qwen model with a regex fallback."""
+
+    out = None
     try:
         out = qwen_intent.predict(text)
-        if not out or not out.get("intent"):
-            out = qwen_intent.predict_fallback(text)
     except Exception:
+        # Propagate to fallback below
+        out = None
+    if not out or not out.get("intent"):
         out = qwen_intent.predict_fallback(text)
     return out
 


### PR DESCRIPTION
## Summary
- Let `qwen_intent.predict` raise errors or return `None` instead of forcing a help intent.
- Ensure `_predict_intent` falls back to regex-based parsing when Qwen prediction fails or gives no intent.

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot_nlu/qwen_intent.py src/sentimental_cap_predictor/chatbot.py`
- `pytest tests/test_chatbot.py`
- `PYTHONPATH=src python - <<'PY'
from sentimental_cap_predictor.chatbot import _predict_intent
print(_predict_intent('run the pipeline now'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ad2463ff6c832bb2f54330caa06f26