### PR TITLE
Add tests for pipeline intent fallback using Qwen

### DIFF
--- a/tests/test_chatbot_nlu_pipeline.py
+++ b/tests/test_chatbot_nlu_pipeline.py
@@ -1,0 +1,19 @@
+import pytest
+
+from sentimental_cap_predictor.chatbot import _predict_intent
+from sentimental_cap_predictor.chatbot_nlu import qwen_intent
+
+
+@pytest.mark.parametrize(
+    "phrase,expected",
+    [
+        ("run the pipeline now", "pipeline.run_now"),
+        ("kick off the pipeline right away", "pipeline.run_now"),
+        ("please run the daily pipeline", "pipeline.run_daily"),
+    ],
+)
+def test_pipeline_intents_fallback(monkeypatch, phrase, expected):
+    # Simulate Qwen failure so the regex fallback triggers
+    monkeypatch.setattr(qwen_intent, "predict", lambda _: None)
+    out = _predict_intent(phrase)
+    assert out["intent"] == expected


### PR DESCRIPTION
## Summary
- add tests ensuring pipeline-related phrases route to run_now or run_daily intents when Qwen NLU fails

## Testing
- `PYTHONPATH=src pytest tests/test_chatbot.py tests/test_chatbot_nlu_pipeline.py -q`
- `PYTHONPATH=src python - <<'PY'
from sentimental_cap_predictor.chatbot import _predict_intent
phrases=["run the pipeline now","please run the daily pipeline","kick off the pipeline right away","start the pipeline daily","run pipeline immediately"]
for p in phrases:
    print(p,'->',_predict_intent(p))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ae1a2507a8832b8393aab89a9d099a