### PR TITLE
Capture ticker slots in NLU fallback

### DIFF
--- a/tests/test_chatbot_nlu_tickers.py
+++ b/tests/test_chatbot_nlu_tickers.py
@@ -1,0 +1,17 @@
+import pytest
+
+from sentimental_cap_predictor.chatbot_nlu import qwen_intent
+
+
+@pytest.mark.parametrize(
+    "phrase,intent,slots",
+    [
+        ("ingest NVDA AAPL", "data.ingest", {"tickers": ["NVDA", "AAPL"]}),
+        ("train NVDA", "model.train_eval", {"ticker": "NVDA"}),
+        ("plot TSLA", "plots.make_report", {"ticker": "TSLA"}),
+    ],
+)
+def test_predict_fallback_ticker_slots(phrase, intent, slots):
+    out = qwen_intent.predict_fallback(phrase)
+    assert out["intent"] == intent
+    assert out["slots"] == slots


### PR DESCRIPTION
## Summary
- Capture ticker tokens for ingest, train, and plot intents in keyword fallback
- Return ticker or tickers slots in fallback intent predictions
- Add tests covering ticker slot extraction

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot_nlu/qwen_intent.py tests/test_chatbot_nlu_tickers.py`
- `pytest tests/test_chatbot_nlu_pipeline.py tests/test_chatbot_nlu_tickers.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae2ff45e80832b8e389be1d98f0b75