### PR TITLE
refactor: consolidate regex import in qwen intent

### DIFF
--- a/src/sentimental_cap_predictor/chatbot_nlu/qwen_intent.py
+++ b/src/sentimental_cap_predictor/chatbot_nlu/qwen_intent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # flake8: noqa
 import json
 import os
-import re
+import re as _re
 from typing import Any, Dict
 
 SYSTEM = """You are an intent classifier and slot extractor for the Cap Predictor CLI.
@@ -77,7 +77,7 @@ def call_qwen(utterance: str) -> str:
     raise RuntimeError(f"Qwen request failed: {msg}")
 
 
-_JSON_RE = re.compile(r"<json>\s*(\{.*\})\s*</json>", re.S)
+_JSON_RE = _re.compile(r"<json>\s*(\{.*\})\s*</json>", _re.S)
 
 
 def predict(utterance: str) -> Dict[str, Any] | None:
@@ -105,7 +105,6 @@ def predict(utterance: str) -> Dict[str, Any] | None:
 
 
 # --- Minimal keyword fallback (used if Qwen not yet wired) ---
-import re as _re  # noqa: E402
 
 _PIPELINE_NOW = _re.compile(
     r"\b(run|start|kick off|execute).*(pipeline|flow).*(now|right away|immediately)?",


### PR DESCRIPTION
## Summary
- consolidate regex imports in Qwen intent classifier
- update JSON regex to use new alias

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot_nlu/qwen_intent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae317425e4832bb3fb92e913496ee9