### PR TITLE
Gate chatbot debug output behind flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.dataset` – download price and news data
 - `sentimental_cap_predictor.plots` – visualize processed data
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
-- `sentimental_cap_predictor.chatbot` – chat with a local Mistral-powered assistant that consults main and experimental models and explains its decisions
+- `sentimental_cap_predictor.chatbot` – chat with a local Mistral-powered assistant that consults main and experimental models and explains its decisions. Set `CHATBOT_DEBUG=1` or pass `--debug` to show predicted intents.
 
 Run `--help` with any module for detailed options.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.dataset` – download price and news data
 - `sentimental_cap_predictor.plots` – visualize processed data
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
-- `sentimental_cap_predictor.chatbot` – chat with a local Mistral-powered assistant that consults main and experimental models and explains its decisions. Set `CHATBOT_DEBUG=1` or pass `--debug` to show predicted intents.
+- `sentimental_cap_predictor.chatbot` – chat with a local Mistral-powered assistant that consults main and experimental models and explains its decisions. Pass `--debug` or set `CHATBOT_DEBUG=1` ("true"/"yes" also work) to show predicted intents.
 
 Run `--help` with any module for detailed options.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each module exposes a Typer application:
 - `sentimental_cap_predictor.dataset` – download price and news data
 - `sentimental_cap_predictor.plots` – visualize processed data
 - `sentimental_cap_predictor.modeling.sentiment_analysis` – train and evaluate sentiment models
-- `sentimental_cap_predictor.chatbot` – chat with a local Mistral-powered assistant that consults main and experimental models and explains its decisions. Pass `--debug` or set `CHATBOT_DEBUG=1` ("true"/"yes" also work) to show predicted intents.
+- `sentimental_cap_predictor.chatbot` – chat with a local Mistral-powered assistant that consults main and experimental models and explains its decisions. Pass `--debug` or set `CHATBOT_DEBUG=1` ("true"/"yes"/"on" also work) to show predicted intents.
 
 Run `--help` with any module for detailed options.
 

--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -222,7 +222,8 @@ def repl(debug: bool | None = None) -> None:
     """
 
     if debug is None:
-        debug = bool(os.getenv("CHATBOT_DEBUG"))
+        debug_env = os.getenv("CHATBOT_DEBUG", "")
+        debug = debug_env.lower() in {"1", "true", "yes", "on"}
 
     print(WELCOME_BANNER)
     while True:

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+from sentimental_cap_predictor import chatbot
 from sentimental_cap_predictor.chatbot import _summarize_decision
 
 
@@ -9,3 +12,26 @@ def test_summarize_decision_agreement():
 def test_summarize_decision_disagreement():
     result = _summarize_decision("yes", "no")
     assert "main model" in result.lower() and "experimental" in result.lower()
+
+
+def _run_repl_once(debug=None):
+    with patch("builtins.input", side_effect=["hi", EOFError()]):
+        with patch(
+            "sentimental_cap_predictor.chatbot._predict_intent",
+            return_value={"intent": "smalltalk.greeting", "slots": {}},
+        ):
+            chatbot.repl(debug=debug)
+
+
+def test_repl_no_debug_output(monkeypatch, capsys):
+    monkeypatch.delenv("CHATBOT_DEBUG", raising=False)
+    _run_repl_once()
+    captured = capsys.readouterr()
+    assert "[debug]" not in captured.out
+
+
+def test_repl_debug_output_env(monkeypatch, capsys):
+    monkeypatch.setenv("CHATBOT_DEBUG", "1")
+    _run_repl_once()
+    captured = capsys.readouterr()
+    assert "[debug] intent=smalltalk.greeting" in captured.out

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -35,3 +35,16 @@ def test_repl_debug_output_env(monkeypatch, capsys):
     _run_repl_once()
     captured = capsys.readouterr()
     assert "[debug] intent=smalltalk.greeting" in captured.out
+
+
+def test_repl_debug_output_env_false(monkeypatch, capsys):
+    monkeypatch.setenv("CHATBOT_DEBUG", "0")
+    _run_repl_once()
+    captured = capsys.readouterr()
+    assert "[debug]" not in captured.out
+
+
+def test_repl_debug_output_flag(capsys):
+    _run_repl_once(debug=True)
+    captured = capsys.readouterr()
+    assert "[debug] intent=smalltalk.greeting" in captured.out

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from sentimental_cap_predictor import chatbot
 from sentimental_cap_predictor.chatbot import _summarize_decision
 
@@ -30,8 +32,9 @@ def test_repl_no_debug_output(monkeypatch, capsys):
     assert "[debug]" not in captured.out
 
 
-def test_repl_debug_output_env(monkeypatch, capsys):
-    monkeypatch.setenv("CHATBOT_DEBUG", "1")
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+def test_repl_debug_output_env(monkeypatch, capsys, value):
+    monkeypatch.setenv("CHATBOT_DEBUG", value)
     _run_repl_once()
     captured = capsys.readouterr()
     assert "[debug] intent=smalltalk.greeting" in captured.out


### PR DESCRIPTION
## Summary
- add `--debug` flag and `CHATBOT_DEBUG` env var to control chatbot intent logging
- document debug flag in README
- test that debug output is shown only when enabled

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot.py README.md tests/test_chatbot.py`
- `pytest tests/test_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae34eb8cac832b9bfd2ddd2f37ed82