### PR TITLE
feat: add base LLM provider protocol

### DIFF
--- a/src/sentimental_cap_predictor/llm_providers/__init__.py
+++ b/src/sentimental_cap_predictor/llm_providers/__init__.py
@@ -1,0 +1,5 @@
+"""Language model provider interfaces."""
+
+__all__ = ["ChatMessage", "LLMProvider"]
+
+from .base import ChatMessage, LLMProvider

--- a/src/sentimental_cap_predictor/llm_providers/base.py
+++ b/src/sentimental_cap_predictor/llm_providers/base.py
@@ -1,0 +1,21 @@
+"""Base interfaces for large language model providers."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Protocol
+
+ChatMessage = Dict[str, str]
+"""A chat message with ``role`` and ``content`` fields."""
+
+
+class LLMProvider(Protocol):
+    """Protocol for chat-based large language model providers."""
+
+    def chat(self, messages: List[ChatMessage], **kwargs: object) -> str:
+        """Generate a reply for a sequence of chat ``messages``.
+
+        Additional keyword arguments may be supplied to configure the
+        provider. The provider should return the generated text response as a
+        string.
+        """
+        ...


### PR DESCRIPTION
## Summary
- add `ChatMessage` type and `LLMProvider` protocol for chat interactions

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_providers/__init__.py src/sentimental_cap_predictor/llm_providers/base.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae4fd1f274832b9ccd902bd0c083e7