### PR TITLE
Add Qwen LLM provider

### DIFF
--- a/src/sentimental_cap_predictor/llm_providers/__init__.py
+++ b/src/sentimental_cap_predictor/llm_providers/__init__.py
@@ -1,0 +1,3 @@
+"""LLM provider integrations."""
+
+__all__ = []

--- a/src/sentimental_cap_predictor/llm_providers/qwen.py
+++ b/src/sentimental_cap_predictor/llm_providers/qwen.py
@@ -1,0 +1,30 @@
+"""Qwen provider using the OpenAI client."""
+
+from __future__ import annotations
+
+try:
+    from openai import OpenAI
+except Exception as exc:  # pragma: no cover - import-time failure
+    raise RuntimeError("OpenAI client is required") from exc
+
+
+class QwenProvider:
+    """Minimal wrapper around an OpenAI-style Qwen endpoint."""
+
+    def __init__(self, api_key: str, model: str, base_url: str, temperature: float) -> None:
+        self.model = model
+        self.temperature = temperature
+        kwargs = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        self.client = OpenAI(**kwargs)
+
+    def chat(self, messages: list[dict[str, str]]) -> str:
+        """Send messages to the Qwen model."""
+
+        completion = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+        )
+        return completion.choices[0].message.get("content", "")


### PR DESCRIPTION
## Summary
- add package for llm providers
- implement QwenProvider wrapper around OpenAI-compatible API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae51516600832bbf54a0ddbc9b8ad4