### PR TITLE
Add OpenAI dependency and installation instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: install lint format test
 
 install:
-	pip install -e .[dev]
+        pip install openai
+        pip install -e .[dev]
 
 lint:
 	pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ flowchart TD
    Fill in API keys and adjust paths or hyperparameters as needed.
 2. **Install dependencies**
    ```bash
+   pip install openai
    pip install -e .[dev]
    ```
 3. **Collect data**

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -8,6 +8,7 @@ Automate the nightly pipeline on Windows using **Task Scheduler**.
    ```powershell
    python -m venv venv
    .\venv\Scripts\activate
+   pip install openai
    pip install -e .
    ```
 2. Configure any required environment variables, for example:

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -7,6 +7,7 @@
   ```
 - Install dependencies in editable mode with development extras:
   ```bash
+  pip install openai
   pip install -e .[dev]
   ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "psutil>=5.9,<6",
     "optuna>=3,<4",
     "lxml-html-clean>=0.4,<1",
+    "openai>=1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add `openai>=1` to project dependencies
- guide developers to install OpenAI Python package
- update installation scripts and docs accordingly

## Testing
- `pre-commit run --files pyproject.toml README.md docs/user_manual.md docs/scheduling.md Makefile`
- `OFFLINE_TEST=1 pytest tests/test_backtester.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae55591e58832ba426c033d3da306c