### PR TITLE
feat: introduce base LLMProvider protocol

### DIFF
--- a/src/sentimental_cap_predictor/llm_providers/base.py
+++ b/src/sentimental_cap_predictor/llm_providers/base.py
@@ -1,0 +1,15 @@
+"""Common types and protocols for LLM providers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Protocol
+
+ChatMessage = Dict[str, str]
+"""Minimal chat message containing ``role`` and ``content`` fields."""
+
+
+class LLMProvider(Protocol):
+    """Protocol for chat-based LLM provider implementations."""
+
+    def chat(self, messages: List[ChatMessage], **kwargs: Any) -> str:
+        """Return the model's response to a list of chat messages."""

--- a/src/sentimental_cap_predictor/llm_providers/qwen.py
+++ b/src/sentimental_cap_predictor/llm_providers/qwen.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 try:
     from openai import OpenAI
 except Exception as exc:  # pragma: no cover - import-time failure
     raise RuntimeError("OpenAI client is required") from exc
 
+from .base import ChatMessage, LLMProvider
 
-class QwenProvider:
-    """Minimal wrapper around an OpenAI-style Qwen endpoint."""
 
-    def __init__(self, api_key: str, model: str, base_url: str, temperature: float) -> None:
+class QwenProvider(LLMProvider):
+    """Implementation of :class:`LLMProvider` for the Qwen API."""
+
+    def __init__(
+        self, api_key: str, model: str, base_url: str, temperature: float
+    ) -> None:
         self.model = model
         self.temperature = temperature
         kwargs = {"api_key": api_key}
@@ -19,12 +25,13 @@ class QwenProvider:
             kwargs["base_url"] = base_url
         self.client = OpenAI(**kwargs)
 
-    def chat(self, messages: list[dict[str, str]]) -> str:
+    def chat(self, messages: list[ChatMessage], **kwargs: Any) -> str:
         """Send messages to the Qwen model."""
 
         completion = self.client.chat.completions.create(
             model=self.model,
             messages=messages,
             temperature=self.temperature,
+            **kwargs,
         )
         return completion.choices[0].message.get("content", "")


### PR DESCRIPTION
## Summary
- add shared `ChatMessage` type and `LLMProvider` protocol
- refactor Qwen provider to implement the new protocol

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_providers/base.py src/sentimental_cap_predictor/llm_providers/qwen.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae5894e754832bb5f4a28782e7d05a