### PR TITLE
chore: constrain openai dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "psutil>=5.9,<6",
     "optuna>=3,<4",
     "lxml-html-clean>=0.4,<1",
-    "openai>=1",
+    "openai>=1,<2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- restrict OpenAI client to major version 1

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae4f5ae7bc832bade58c59628081fc