### PR TITLE
feat: add local qwen provider

### DIFF
--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -1,8 +1,8 @@
 # Chatbot Frontend
 
-This module provides a minimal REPL interface to a Qwen chat model. It
-reads configuration from environment variables (loaded with `python-dotenv`) and
-communicates with an external runner through a simple `CMD:` protocol.
+This module provides a minimal REPL interface to a **local** Qwen chat model.
+It reads configuration from environment variables (loaded with `python-dotenv`)
+and communicates with an external runner through a simple `CMD:` protocol.
 
 ## Environment variables
 
@@ -11,12 +11,26 @@ defaults when they are unset:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `QWEN_BASE_URL` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | Base URL for the Qwen endpoint |
-| `QWEN_API_KEY` | *(empty string)* | API key used to authenticate requests |
-| `QWEN_MODEL` | `qwen-max` | Model name passed to the API |
+| `QWEN_MODEL_PATH` | `Qwen/Qwen2-1.5B-Instruct` | Local path or HF repository for the weights |
 | `LLM_TEMPERATURE` | `0.7` | Sampling temperature |
 
 Variables can be placed in a `.env` file which is loaded automatically.
+
+## Dependencies and weights
+
+Install the required libraries:
+
+```bash
+pip install transformers torch
+```
+
+Download the Qwen weights (for example using the Hugging Face CLI):
+
+```bash
+huggingface-cli download Qwen/Qwen2-1.5B-Instruct --local-dir /path/to/qwen
+```
+
+Set `QWEN_MODEL_PATH` to the directory containing the weights.
 
 ## Run
 

--- a/src/sentimental_cap_predictor/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/chatbot_frontend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sentimental_cap_predictor.config_llm import get_llm_config
-from sentimental_cap_predictor.llm_providers.qwen import QwenProvider
+from sentimental_cap_predictor.llm_providers.qwen_local import QwenLocalProvider
 
 SYSTEM_PROMPT = (
     "You are a helpful assistant."
@@ -13,9 +13,9 @@ SYSTEM_PROMPT = (
 
 
 def main() -> None:
-    """Run a REPL-style chat session with the Qwen model."""
+    """Run a REPL-style chat session with the local Qwen model."""
     config = get_llm_config()
-    provider = QwenProvider(**config)
+    provider = QwenLocalProvider(**config)
     history: list[dict[str, str]] = [
         {"role": "system", "content": SYSTEM_PROMPT},
     ]

--- a/src/sentimental_cap_predictor/config_llm.py
+++ b/src/sentimental_cap_predictor/config_llm.py
@@ -11,17 +11,11 @@ load_dotenv()
 
 
 def get_llm_config() -> dict[str, Any]:
-    """Return configuration for Qwen LLM from environment variables."""
+    """Return configuration for a local Qwen LLM."""
 
-    base_url = os.getenv(
-        "QWEN_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1"
-    )
-    api_key = os.getenv("QWEN_API_KEY", "")
-    model = os.getenv("QWEN_MODEL", "qwen-max")
+    model_path = os.getenv("QWEN_MODEL_PATH", "Qwen/Qwen2-1.5B-Instruct")
     temperature = float(os.getenv("LLM_TEMPERATURE", 0.7))
     return {
-        "base_url": base_url,
-        "api_key": api_key,
-        "model": model,
+        "model_path": model_path,
         "temperature": temperature,
     }

--- a/src/sentimental_cap_predictor/llm_providers/qwen_local.py
+++ b/src/sentimental_cap_predictor/llm_providers/qwen_local.py
@@ -1,0 +1,36 @@
+"""Qwen provider using local transformer weights."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from .base import ChatMessage, LLMProvider
+
+
+class QwenLocalProvider(LLMProvider):
+    """Implementation of :class:`LLMProvider` for a local Qwen model."""
+
+    def __init__(self, model_path: str, temperature: float) -> None:
+        self.temperature = temperature
+        self.tokenizer = AutoTokenizer.from_pretrained(model_path)
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_path, device_map="auto"
+        )
+        self.model.eval()
+
+    def chat(self, messages: List[ChatMessage], **kwargs: Any) -> str:
+        """Return the model's response to a list of chat messages."""
+
+        prompt = self.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.model.device)
+        with torch.no_grad():
+            outputs = self.model.generate(
+                **inputs, temperature=self.temperature, **kwargs
+            )
+        generated = outputs[0, inputs["input_ids"].shape[-1] :]
+        return self.tokenizer.decode(generated, skip_special_tokens=True)


### PR DESCRIPTION
## Summary
- support running Qwen locally via `QwenLocalProvider`
- simplify LLM config to accept model path and temperature
- document local Qwen dependencies and weight download

## Testing
- `OFFLINE_TEST=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af33b98948832bba1377c95dc76830