### PR TITLE
Add local Qwen provider with accelerate

### DIFF
--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -18,10 +18,19 @@ Variables can be placed in a `.env` file which is loaded automatically.
 
 ## Dependencies and weights
 
-Install the required libraries:
+Install the required libraries.  The local provider relies on
+`transformers`, `accelerate`, and `safetensors` in addition to `torch`:
 
 ```bash
-pip install transformers torch
+pip install transformers accelerate safetensors torch
+```
+
+If you need an offline setup, download the wheels ahead of time and
+install from the local directory:
+
+```bash
+pip download transformers accelerate safetensors torch -d ./wheels
+pip install --no-index --find-links=./wheels transformers accelerate safetensors torch
 ```
 
 Download the Qwen weights (for example using the Hugging Face CLI):
@@ -30,7 +39,8 @@ Download the Qwen weights (for example using the Hugging Face CLI):
 huggingface-cli download Qwen/Qwen2-1.5B-Instruct --local-dir /path/to/qwen
 ```
 
-Set `QWEN_MODEL_PATH` to the directory containing the weights.
+Set `QWEN_MODEL_PATH` to the directory containing the weights so the model
+can be loaded entirely offline.
 
 ## Run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "requests>=2.31,<3",
     "newspaper3k>=0.2,<0.3",
     "transformers>=4.30,<5",
+    "accelerate>=0.30,<1",
+    "safetensors>=0.4,<1",
     "torch==2.2.2",
     "pydantic==2.11.7",
     "prefect==3.4.13",

--- a/src/sentimental_cap_predictor/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/chatbot_frontend.py
@@ -15,7 +15,9 @@ SYSTEM_PROMPT = (
 def main() -> None:
     """Run a REPL-style chat session with the local Qwen model."""
     config = get_llm_config()
-    provider = QwenLocalProvider(**config)
+    provider = QwenLocalProvider(
+        model_path=config.model_path, temperature=config.temperature
+    )
     history: list[dict[str, str]] = [
         {"role": "system", "content": SYSTEM_PROMPT},
     ]

--- a/src/sentimental_cap_predictor/config_llm.py
+++ b/src/sentimental_cap_predictor/config_llm.py
@@ -3,19 +3,24 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from dataclasses import dataclass
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
 
-def get_llm_config() -> dict[str, Any]:
+@dataclass
+class LLMConfig:
+    """Configuration values for a local Qwen model."""
+
+    model_path: str
+    temperature: float
+
+
+def get_llm_config() -> LLMConfig:
     """Return configuration for a local Qwen LLM."""
 
     model_path = os.getenv("QWEN_MODEL_PATH", "Qwen/Qwen2-1.5B-Instruct")
     temperature = float(os.getenv("LLM_TEMPERATURE", 0.7))
-    return {
-        "model_path": model_path,
-        "temperature": temperature,
-    }
+    return LLMConfig(model_path=model_path, temperature=temperature)


### PR DESCRIPTION
## Summary
- load Hugging Face Qwen checkpoints locally with an accelerate-backed provider
- expose model_path config and wire QwenLocalProvider into chatbot_frontend
- document offline setup including package downloads and weight retrieval

## Testing
- `ruff check src/sentimental_cap_predictor/llm_providers/qwen_local.py src/sentimental_cap_predictor/config_llm.py src/sentimental_cap_predictor/chatbot_frontend.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af64c16fe8832b9a26086556696592