### PR TITLE
Safely evaluate metric expressions via AST

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -27,6 +27,19 @@ def test_objective_supports_expression():
     assert value == pytest.approx(0.9)
 
 
+def test_objective_rejects_malicious_expression():
+    metrics = {"sharpe_ratio": 1.0}
+    with pytest.raises(ValueError):
+        objective(metrics, expression="__import__('os').system('echo hacked')")
+
+
+def test_objective_supports_weights():
+    metrics = {"sharpe_ratio": 1.0, "max_drawdown": -0.2}
+    weights = {"sharpe_ratio": 1.0, "max_drawdown": 0.5}
+    value = objective(metrics, weights=weights)
+    assert value == pytest.approx(0.9)
+
+
 def test_passes_constraints_configurable():
     metrics = {"trade_count": 40, "max_drawdown": -0.1, "volatility": 0.15}
     constraints = Constraints(max_drawdown=0.05)


### PR DESCRIPTION
## Summary
- Replace `eval` in strategy objective with an AST-based evaluator limited to arithmetic and metric names
- Reject invalid or malicious expressions with clear errors
- Test safe expression handling and weight-based objectives

## Testing
- `pytest tests/test_evaluation.py::test_objective_supports_expression -q`
- `pytest tests/test_evaluation.py::test_objective_rejects_malicious_expression -q`
- `pytest tests/test_evaluation.py::test_objective_supports_weights -q`
- `pytest tests/test_evaluation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0de1ca65c832b967b67e30b901e42