### PR TITLE
Add timeout handling for GDELT queries

### DIFF
--- a/src/sentimental_cap_predictor/dataset.py
+++ b/src/sentimental_cap_predictor/dataset.py
@@ -64,13 +64,20 @@ def query_gdelt_for_news(ticker: str, start_date: str, end_date: str) -> pd.Data
     }
 
     try:
-        response = requests.get(url, params=params)
+        response = requests.get(url, params=params, timeout=30)
         response.raise_for_status()
         data = response.json()
         articles = data.get("articles", [])
         return pd.DataFrame(articles)
-    except requests.exceptions.RequestException as err:
-        logger.error(f"{Fore.RED}Error querying GDELT API: {err}{Style.RESET_ALL}")
+    except requests.Timeout:
+        logger.error(
+            f"{Fore.RED}GDELT API request timed out for {ticker}{Style.RESET_ALL}"
+        )
+        return pd.DataFrame()
+    except requests.RequestException as err:
+        logger.error(
+            f"{Fore.RED}Error querying GDELT API for {ticker}: {err}{Style.RESET_ALL}"
+        )
         return pd.DataFrame()
 
 


### PR DESCRIPTION
## Summary
- ensure `query_gdelt_for_news` uses a 30s timeout and logs timeouts separately
- add tests confirming the timeout parameter is passed and timeout errors return empty dataframes

## Testing
- `pytest tests/test_news.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e2785320832bb5ef8f82cb6da6f2