### PR TITLE
Refactor chatbot pipeline helper

### DIFF
--- a/src/sentimental_cap_predictor/chatbot.py
+++ b/src/sentimental_cap_predictor/chatbot.py
@@ -66,6 +66,7 @@ ABOUT_TEXT = (
     'If you\'re unsure what to say, just ask "what can you do?"'
 )
 
+
 def _run(cmd_list: list[str]) -> str:
     try:
         proc = subprocess.run(
@@ -79,8 +80,11 @@ def _run(cmd_list: list[str]) -> str:
         return f"Command failed: {e}"
 
 
-def _run_daily_pipeline(ticker: str, period: str, interval: str) -> str:
-    """Run the project's daily pipeline for ``ticker`` via subprocess."""
+def _run_pipeline_from_slots(slots: Dict[str, Any]) -> str:
+    """Build and run the daily pipeline command based on NLU slots."""
+    ticker = slots.get("ticker") or "NVDA"
+    period = slots.get("period") or "5y"
+    interval = slots.get("interval") or "1d"
     args = [
         sys.executable,
         "-m",
@@ -112,16 +116,10 @@ def dispatch(intent: str, slots: Dict[str, Any]) -> str:
 
     # Actions (prefer calling your existing CLI modules via subprocess)
     if intent == "pipeline.run_now":
-        ticker = slots.get("ticker") or "NVDA"
-        period = slots.get("period") or "5y"
-        interval = slots.get("interval") or "1d"
-        return _run_daily_pipeline(ticker, period, interval)
+        return _run_pipeline_from_slots(slots)
 
     if intent == "pipeline.run_daily":
-        ticker = slots.get("ticker") or "NVDA"
-        period = slots.get("period") or "5y"
-        interval = slots.get("interval") or "1d"
-        return _run_daily_pipeline(ticker, period, interval)
+        return _run_pipeline_from_slots(slots)
 
     if intent == "data.ingest":
         tickers = slots.get("tickers") or slots.get("ticker") or []

--- a/src/sentimental_cap_predictor/chatbot_nlu/qwen_intent.py
+++ b/src/sentimental_cap_predictor/chatbot_nlu/qwen_intent.py
@@ -7,7 +7,6 @@ import re as _re
 from typing import Any, Dict
 
 from sentimental_cap_predictor.config_llm import get_llm_config
-from sentimental_cap_predictor.llm_providers.qwen_local import QwenLocalProvider
 
 SYSTEM = """You are an intent classifier and slot extractor for the Cap Predictor CLI.
 Return ONLY JSON between <json>...</json>. Choose the intent from this FIXED list:
@@ -51,11 +50,13 @@ def call_qwen(utterance: str) -> str:
 
     global _LOCAL_PROVIDER
     if _LOCAL_PROVIDER is None:
+        from sentimental_cap_predictor.llm_providers.qwen_local import (
+            QwenLocalProvider,
+        )
+
         cfg = get_llm_config()
         # Use deterministic settings for intent classification
-        _LOCAL_PROVIDER = QwenLocalProvider(
-            model_path=cfg.model_path, temperature=0.0
-        )
+        _LOCAL_PROVIDER = QwenLocalProvider(model_path=cfg.model_path, temperature=0.0)
 
     messages = [
         {"role": "system", "content": SYSTEM},

--- a/tests/test_chatbot_pipeline.py
+++ b/tests/test_chatbot_pipeline.py
@@ -1,0 +1,21 @@
+from sentimental_cap_predictor import chatbot
+
+
+def test_pipeline_intents_call_helper(monkeypatch):
+    calls = []
+
+    def fake_helper(slots):
+        calls.append(slots)
+        return "ok"
+
+    monkeypatch.setattr(chatbot, "_run_pipeline_from_slots", fake_helper)
+
+    slots = {"ticker": "TSLA", "period": "1y", "interval": "1d"}
+
+    out = chatbot.dispatch("pipeline.run_now", slots)
+    assert out == "ok"
+
+    out = chatbot.dispatch("pipeline.run_daily", slots)
+    assert out == "ok"
+
+    assert calls == [slots, slots]


### PR DESCRIPTION
## Summary
- add `_run_pipeline_from_slots` helper for pipeline commands
- route both `pipeline.run_now` and `pipeline.run_daily` intents through the helper
- lazily import Qwen provider to avoid heavy dependencies
- cover pipeline intents via new chatbot test

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot.py tests/test_chatbot_pipeline.py src/sentimental_cap_predictor/chatbot_nlu/qwen_intent.py`
- `pytest tests/test_chatbot_nlu_pipeline.py tests/test_chatbot_nlu_tickers.py tests/test_chatbot_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0f0680130832b94b27690ccf26a66