### PR TITLE
refactor: split training and prediction

### DIFF
--- a/src/sentimental_cap_predictor/features.py
+++ b/src/sentimental_cap_predictor/features.py
@@ -10,7 +10,11 @@ import warnings
 import traceback
 
 from .preprocessing import preprocess_price_data, merge_data
-from .model_training import train_and_predict
+from .model_training import (
+    train_model,
+    predict_on_future_data,
+    predict_on_test_data,
+)
 from .data_bundle import DataBundle
 from .dataset import load_data_bundle
 
@@ -143,12 +147,17 @@ def train_and_predict_model(
     mode: str,
     prediction_days: int,
     sentiment_df: pd.DataFrame,
+    seed: int | None = None,
 ):
     """Run model training and prediction."""
     try:
-        price_df = train_and_predict(
-            price_df, train_data, test_data, mode, prediction_days, sentiment_df
-        )
+        model = train_model(train_data, random_state=seed)
+        if mode == "train_test":
+            price_df = predict_on_test_data(price_df, model, test_data, sentiment_df)
+        else:
+            price_df = predict_on_future_data(
+                price_df, model, prediction_days, sentiment_df
+            )
         print_nan_info(price_df, "deep_learning_predictions")
         return price_df
     except Exception as e:  # pragma: no cover - defensive

--- a/src/sentimental_cap_predictor/flows/daily_pipeline.py
+++ b/src/sentimental_cap_predictor/flows/daily_pipeline.py
@@ -17,7 +17,7 @@ from loguru import logger
 
 from ..config import ENABLE_TICKER_LOGS
 from ..data import ingest as data_ingest
-from ..model_training import train_and_predict
+from ..model_training import train_model, predict_on_test_data
 from ..preprocessing import preprocess_price_data
 from ..trader_utils import strategy_optimizer as strat_opt
 
@@ -54,13 +54,9 @@ def run(
     test_df = processed.iloc[split_idx:]
 
     # Model training / prediction
-    preds = train_and_predict(
-        processed.copy(),
-        train_df,
-        test_df,
-        mode="train_test",
-        prediction_days=0,
-        sentiment_df=pd.DataFrame(),
+    model = train_model(train_df, random_state=42)
+    preds = predict_on_test_data(
+        processed.copy(), model, test_df, pd.DataFrame()
     )
 
     valid = preds.loc[test_df.index].dropna(subset=["predicted"])

--- a/src/sentimental_cap_predictor/model_training.py
+++ b/src/sentimental_cap_predictor/model_training.py
@@ -1,60 +1,56 @@
-"""Model construction and training helpers.
-
-This module isolates the logic for building the Liquid Neural
-Network model and generating predictions so that command line
-interfaces can remain focused on argument parsing and I/O.
-"""
+"""Model construction, training and prediction helpers."""
 from __future__ import annotations
 
 import numpy as np
 import pandas as pd
 from loguru import logger
 
-from .modeling.time_series_deep_learner import build_liquid_model, train_model_with_rolling_window
+from .modeling.time_series_deep_learner import (
+    build_liquid_model,
+    train_model_with_rolling_window,
+)
 from .modeling.bias_predictions import bias_predictions_with_sentiment
 
 
-def train_and_predict(
-    price_df: pd.DataFrame,
+def train_model(
     train_data: pd.DataFrame,
-    test_data: pd.DataFrame,
-    mode: str,
-    prediction_days: int,
-    sentiment_df: pd.DataFrame,
     timesteps: int = 1,
-) -> pd.DataFrame:
-    """Train the LNN model and append predictions to ``price_df``.
+    random_state: int | None = None,
+    validation_split: float = 0.2,
+):
+    """Train the Liquid Neural Network model on ``train_data``.
 
     Parameters
     ----------
-    price_df:
-        Complete dataframe containing the ``close`` series used for
-        training. It will be updated with prediction columns.
-    train_data, test_data:
-        Split subsets of ``price_df`` used for training and testing.
-    mode:
-        Either ``'train_test'`` or ``'production'``.
-    prediction_days:
-        Number of future days to predict in production mode.
-    sentiment_df:
-        Dataframe containing sentiment information used to bias
-        predictions.
+    train_data:
+        DataFrame containing the ``close`` series used for training.
     timesteps:
         Number of timesteps for the model input shape.
+    random_state:
+        Optional seed to make training deterministic.
+    validation_split:
+        Fraction of data used for validation during training.
     """
     logger.info("Applying Liquid Neural Network for non-linear feature extraction.")
 
-    # Prepare training arrays
-    X_train = np.reshape(train_data["close"].values, (train_data.shape[0], timesteps, 1))
+    if random_state is not None:
+        np.random.seed(random_state)
+        try:  # TensorFlow may not be installed in all environments
+            import tensorflow as tf
+
+            tf.random.set_seed(random_state)
+        except ModuleNotFoundError:  # pragma: no cover - fallback for missing TF
+            pass
+
+    X_train = np.reshape(
+        train_data["close"].values, (train_data.shape[0], timesteps, 1)
+    )
     y_train = train_data["close"].values
 
     model = build_liquid_model(input_shape=(timesteps, 1))
 
-    if mode == "train_test":
-        X_test = np.reshape(test_data["close"].values, (test_data.shape[0], timesteps, 1))
-        y_test = test_data["close"].values  # noqa: F841 - y_test kept for potential future use
-
-        val_size = int(len(X_train) * 0.2)
+    val_size = int(len(X_train) * validation_split)
+    if val_size > 0:
         X_val, y_val = X_train[-val_size:], y_train[-val_size:]
         train_model_with_rolling_window(
             model,
@@ -64,30 +60,54 @@ def train_and_predict(
             y_val,
             window_size=100,
         )
-
-        predictions = model.predict(X_test).flatten()
-        test_data = test_data.copy()
-        test_data["predicted"] = predictions
-        test_data = bias_predictions_with_sentiment(test_data, sentiment_df)
-        price_df.loc[test_data.index, "predicted"] = predictions
-        price_df.update(test_data)
-    else:  # production mode
+    else:
         train_model_with_rolling_window(model, X_train, y_train)
-        last_data = X_train[-timesteps:]
-        predictions = []
-        for _ in range(prediction_days):
-            next_pred = model.predict(last_data.reshape(1, timesteps, 1)).flatten()
-            predictions.append(next_pred[0])
-            last_data = np.append(last_data[1:], next_pred).reshape(timesteps, 1)
 
-        future_dates = pd.date_range(
-            start=price_df.index[-1] + pd.Timedelta(days=1),
-            periods=prediction_days,
-            freq="D",
-        )
-        future_df = pd.DataFrame(index=future_dates, data=predictions, columns=["predicted"])
-        future_df = bias_predictions_with_sentiment(future_df, sentiment_df)
-        price_df = pd.concat([price_df, future_df])
-        price_df.update(future_df)
+    return model
 
+
+def predict_on_test_data(
+    price_df: pd.DataFrame,
+    model,
+    test_data: pd.DataFrame,
+    sentiment_df: pd.DataFrame,
+    timesteps: int = 1,
+) -> pd.DataFrame:
+    """Generate predictions for ``test_data`` and append to ``price_df``."""
+    X_test = np.reshape(test_data["close"].values, (test_data.shape[0], timesteps, 1))
+    predictions = model.predict(X_test).flatten()
+    test_data = test_data.copy()
+    test_data["predicted"] = predictions
+    test_data = bias_predictions_with_sentiment(test_data, sentiment_df)
+    price_df.loc[test_data.index, "predicted"] = predictions
+    price_df.update(test_data)
+    return price_df
+
+
+def predict_on_future_data(
+    price_df: pd.DataFrame,
+    model,
+    prediction_days: int,
+    sentiment_df: pd.DataFrame,
+    timesteps: int = 1,
+) -> pd.DataFrame:
+    """Forecast future days and append predictions to ``price_df``."""
+    last_data = np.reshape(
+        price_df["close"].values[-timesteps:], (timesteps, 1)
+    )
+    predictions: list[float] = []
+    for _ in range(prediction_days):
+        next_pred = model.predict(last_data.reshape(1, timesteps, 1)).flatten()
+        predictions.append(next_pred[0])
+        last_data = np.append(last_data[1:], next_pred).reshape(timesteps, 1)
+
+    future_dates = pd.date_range(
+        start=price_df.index[-1] + pd.Timedelta(days=1),
+        periods=prediction_days,
+        freq="D",
+    )
+    future_df = pd.DataFrame(index=future_dates, data=predictions, columns=["predicted"])
+    future_df = bias_predictions_with_sentiment(future_df, sentiment_df)
+    price_df = pd.concat([price_df, future_df])
+    price_df.update(future_df)
     return price_df

--- a/tests/test_feature_builder.py
+++ b/tests/test_feature_builder.py
@@ -19,7 +19,11 @@ features_mod = importlib.util.module_from_spec(spec)
 sys.modules["sentimental_cap_predictor._features"] = features_mod
 sys.modules.setdefault(
     "sentimental_cap_predictor.model_training",
-    types.SimpleNamespace(train_and_predict=lambda *a, **k: None),
+    types.SimpleNamespace(
+        train_model=lambda *a, **k: None,
+        predict_on_future_data=lambda *a, **k: None,
+        predict_on_test_data=lambda *a, **k: None,
+    ),
 )
 sys.modules.setdefault(
     "modeling.sentiment_analysis",

--- a/tests/test_model_training.py
+++ b/tests/test_model_training.py
@@ -1,11 +1,11 @@
-import types
 import sys
+import types
 import numpy as np
 import pandas as pd
 
 # Inject a lightweight substitute for the TensorFlow-dependent module
-build_calls = []
-train_calls = []
+build_calls: list[tuple] = []
+train_calls: list[bool] = []
 
 dummy_module = types.ModuleType("time_series_deep_learner")
 
@@ -30,16 +30,37 @@ dummy_module.train_model_with_rolling_window = fake_train_model_with_rolling_win
 
 sys.modules["sentimental_cap_predictor.modeling.time_series_deep_learner"] = dummy_module
 
-from sentimental_cap_predictor.model_training import train_and_predict
+
+def test_train_model_sets_seeds_and_trains(monkeypatch):
+    np_seeds: list[int] = []
+    tf_seeds: list[int] = []
+
+    monkeypatch.setattr(np.random, "seed", lambda s: np_seeds.append(s))
+    fake_tf = types.SimpleNamespace(random=types.SimpleNamespace(set_seed=lambda s: tf_seeds.append(s)))
+    sys.modules["tensorflow"] = fake_tf
+
+    from sentimental_cap_predictor.model_training import train_model
+
+    price_df = pd.DataFrame({"close": [1, 2, 3]}, index=pd.date_range("2024-01-01", periods=3))
+    model = train_model(price_df, random_state=123)
+    assert isinstance(model, DummyModel)
+    assert build_calls and train_calls
+    assert np_seeds == [123]
+    assert tf_seeds == [123]
 
 
-def test_train_and_predict_calls_lnn_components(monkeypatch):
+def test_predict_on_test_data(monkeypatch):
+    from sentimental_cap_predictor.model_training import (
+        train_model,
+        predict_on_test_data,
+    )
+
     price_df = pd.DataFrame({"close": [1, 2, 3, 4]}, index=pd.date_range("2024-01-01", periods=4))
     train_df = price_df.iloc[:2]
     test_df = price_df.iloc[2:]
-    sentiment_df = pd.DataFrame(columns=["date", "sentiment", "confidence"])
+    sentiment_df = pd.DataFrame(columns=["sentiment"])
 
-    bias_calls = []
+    bias_calls: list[bool] = []
 
     def fake_bias(df, sentiment):
         bias_calls.append(True)
@@ -50,17 +71,33 @@ def test_train_and_predict_calls_lnn_components(monkeypatch):
         fake_bias,
     )
 
-    result = train_and_predict(
-        price_df.copy(),
-        train_df.copy(),
-        test_df.copy(),
-        "train_test",
-        prediction_days=2,
-        sentiment_df=sentiment_df,
-    )
-
+    model = train_model(train_df)
+    result = predict_on_test_data(price_df.copy(), model, test_df.copy(), sentiment_df)
     assert "predicted" in result.columns
-    assert build_calls
-    assert train_calls
     assert bias_calls
 
+
+def test_predict_on_future_data(monkeypatch):
+    from sentimental_cap_predictor.model_training import (
+        train_model,
+        predict_on_future_data,
+    )
+
+    price_df = pd.DataFrame({"close": [1, 2, 3, 4]}, index=pd.date_range("2024-01-01", periods=4))
+    sentiment_df = pd.DataFrame(columns=["sentiment"])
+
+    bias_calls: list[bool] = []
+
+    def fake_bias(df, sentiment):
+        bias_calls.append(True)
+        return df
+
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.model_training.bias_predictions_with_sentiment",
+        fake_bias,
+    )
+
+    model = train_model(price_df)
+    result = predict_on_future_data(price_df.copy(), model, 2, sentiment_df)
+    assert len(result) == len(price_df) + 2
+    assert bias_calls

--- a/tests/test_ticker_logs.py
+++ b/tests/test_ticker_logs.py
@@ -1,4 +1,5 @@
 import sys
+import sys
 import pandas as pd
 
 from types import SimpleNamespace, ModuleType
@@ -11,7 +12,12 @@ def _stub_prices():
 
 def test_ticker_logs_flag(monkeypatch, caplog, tmp_path):
     stub_module = ModuleType("sentimental_cap_predictor.model_training")
-    stub_module.train_and_predict = lambda processed, train_df, test_df, mode, prediction_days, sentiment_df: processed.assign(predicted=processed['close'])
+    stub_module.train_model = lambda train_df, random_state=None: None
+    stub_module.predict_on_test_data = (
+        lambda processed, model, test_df, sentiment_df: processed.assign(
+            predicted=processed['close']
+        )
+    )
     monkeypatch.setitem(sys.modules, 'sentimental_cap_predictor.model_training', stub_module)
 
     from sentimental_cap_predictor.flows import daily_pipeline as dp


### PR DESCRIPTION
## Summary
- refactor training utilities into train_model, predict_on_test_data, and predict_on_future_data
- allow deterministic training via optional random_state
- update feature generation, daily pipeline, and tests for new API

## Testing
- `pytest tests/test_model_training.py tests/test_ticker_logs.py tests/test_feature_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0f4a2a904832b8e648892477a3a6b