### PR TITLE
Generalize news query interface

### DIFF
--- a/src/sentimental_cap_predictor/dataset.py
+++ b/src/sentimental_cap_predictor/dataset.py
@@ -48,14 +48,14 @@ def check_for_nan(df: pd.DataFrame, context: str = "") -> None:
             )
 
 
-def query_gdelt_for_news(ticker: str, start_date: str, end_date: str) -> pd.DataFrame:
-    """Query GDELT API to get news articles based on a ticker and date range."""
+def query_gdelt_for_news(query: str, start_date: str, end_date: str) -> pd.DataFrame:
+    """Query the GDELT API for articles matching ``query`` within a date range."""
     url = os.getenv(
         "GDELT_API_URL", "https://api.gdeltproject.org/api/v2/doc/doc"
     )  # Default value provided
 
     params = {
-        "query": ticker,
+        "query": query,
         "mode": "artlist",
         "startdatetime": start_date,
         "enddatetime": end_date,
@@ -71,12 +71,12 @@ def query_gdelt_for_news(ticker: str, start_date: str, end_date: str) -> pd.Data
         return pd.DataFrame(articles)
     except requests.Timeout:
         logger.error(
-            f"{Fore.RED}GDELT API request timed out for {ticker}{Style.RESET_ALL}"
+            f"{Fore.RED}GDELT API request timed out for {query}{Style.RESET_ALL}"
         )
         return pd.DataFrame()
     except requests.RequestException as err:
         logger.error(
-            f"{Fore.RED}Error querying GDELT API for {ticker}: {err}{Style.RESET_ALL}"
+            f"{Fore.RED}Error querying GDELT API for {query}: {err}{Style.RESET_ALL}"
         )
         return pd.DataFrame()
 

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -11,7 +11,12 @@ from sentimental_cap_predictor.data.news import (
 
 
 def test_fetch_news_returns_columns():
-    df = fetch_news("NVDA")
+    df = fetch_news(query="NVDA")
+    assert list(df.columns) == ["date", "headline", "source"]
+
+
+def test_fetch_news_ticker_keyword_backwards_compatibility():
+    df = fetch_news(ticker="NVDA")
     assert list(df.columns) == ["date", "headline", "source"]
 
 
@@ -27,7 +32,7 @@ def test_file_source_reads_csv(tmp_path):
     ).to_csv(csv_path, index=False)
 
     source = FileSource(csv_path)
-    df = source.fetch("NVDA")
+    df = source.fetch(query="NVDA")
     assert len(df) == 1
     assert df.iloc[0]["headline"] == "Example"
     assert list(df.columns) == ["date", "headline", "source"]
@@ -58,7 +63,7 @@ def test_gdelt_source_fetch(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
 
     source = GDELTSource(days=1, max_records=1)
-    df = source.fetch("NVDA")
+    df = source.fetch(query="NVDA")
     assert list(df.columns) == ["date", "headline", "source"]
     assert df.iloc[0]["headline"] == "Example"
     assert df.iloc[0]["source"] == "Feed"
@@ -114,7 +119,7 @@ def test_query_gdelt_for_news_uses_timeout(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
 
     df = dataset.query_gdelt_for_news(
-        "NVDA", "20240101000000", "20240102000000"
+        query="NVDA", start_date="20240101000000", end_date="20240102000000"
     )
     assert captured["timeout"] == 30
     assert isinstance(df, pd.DataFrame)
@@ -127,6 +132,6 @@ def test_query_gdelt_for_news_handles_timeout(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
 
     df = dataset.query_gdelt_for_news(
-        "NVDA", "20240101000000", "20240102000000"
+        query="NVDA", start_date="20240101000000", end_date="20240102000000"
     )
     assert df.empty


### PR DESCRIPTION
## Summary
- support generic search terms by renaming ticker parameters to query
- update news sources and fetch helpers for query-based lookups with backward-compatible ticker alias
- adjust tests for new interface and add coverage for legacy ticker keyword

## Testing
- `pytest tests/test_news.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3a522caac832b8413724009e85216