### PR TITLE
Add info lookup intent with news connector support

### DIFF
--- a/tests/test_chatbot_lookup.py
+++ b/tests/test_chatbot_lookup.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import pytest
+
+from sentimental_cap_predictor import chatbot
+from sentimental_cap_predictor.chatbot import _predict_intent
+from sentimental_cap_predictor.chatbot_nlu import qwen_intent
+
+
+def test_info_lookup_intent_fallback(monkeypatch):
+    monkeypatch.setattr(qwen_intent, "predict", lambda _: None)
+    out = _predict_intent("news about NVDA")
+    assert out["intent"] == "info.lookup"
+    assert out["slots"] == {"query": "NVDA"}
+
+
+def test_info_lookup_dispatch_calls_fetch_news(monkeypatch):
+    calls = []
+
+    def fake_fetch_news(query):
+        calls.append(query)
+        return pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2024-01-01")],
+                "headline": ["Sample headline"],
+                "source": ["Test"],
+            }
+        )
+
+    monkeypatch.setattr(chatbot, "fetch_news", fake_fetch_news)
+    out = chatbot.dispatch("info.lookup", {"query": "NVDA"})
+    assert "Sample headline" in out
+    assert calls == ["NVDA"]


### PR DESCRIPTION
## Summary
- extend chatbot NLU with new `info.lookup` intent and regex fallback
- hook news lookup into chatbot dispatch and update helper text
- add unit tests for intent recognition and connector invocation

## Testing
- `pytest tests/test_chatbot_lookup.py tests/test_chatbot_nlu_pipeline.py tests/test_chatbot_nlu_tickers.py tests/test_chatbot_pipeline.py -q`
- `pytest tests/test_chatbot_lookup.py tests/test_chatbot_nlu_pipeline.py tests/test_chatbot_nlu_tickers.py tests/test_chatbot_pipeline.py tests/test_news.py -q` *(fails: No module named 'newspaper')*


------
https://chatgpt.com/codex/tasks/task_e_68b3a824461c832bb0cd315a86a33149