### PR TITLE
Expose research connectors through chatbot

### DIFF
--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -54,3 +54,17 @@ The assistant may request that the external environment run shell commands by
 starting a reply with `CMD:` followed by the command string. The runner detects
 these lines, executes the command in a shell, and feeds the captured output back
 into the conversation so the model can continue the dialogue.
+
+## Connector intents
+
+The chatbot understands simple phrases to pull data from a few external
+sources:
+
+- `arxiv machine learning`
+- `pubmed cancer research`
+- `openalex reinforcement learning`
+- `fred GDP`
+- `github repo openai/gpt-4`
+
+Each phrase maps to an intent (e.g. `info.arxiv`, `info.fred`) which invokes the
+corresponding connector helper.

--- a/tests/test_chatbot_lookup.py
+++ b/tests/test_chatbot_lookup.py
@@ -30,3 +30,88 @@ def test_info_lookup_dispatch_calls_fetch_news(monkeypatch):
     out = chatbot.dispatch("info.lookup", {"query": "NVDA"})
     assert "Sample headline" in out
     assert calls == ["NVDA"]
+
+
+def test_arxiv_intent_and_dispatch(monkeypatch):
+    monkeypatch.setattr(qwen_intent, "predict", lambda _: None)
+    out = _predict_intent("arxiv machine learning")
+    assert out == {"intent": "info.arxiv", "slots": {"query": "machine learning"}}
+
+    calls = []
+
+    def fake_fetch(query, max_results=5):
+        calls.append((query, max_results))
+        return [{"title": "Paper", "updated": "2024-01-01"}]
+
+    monkeypatch.setattr(chatbot.arxiv_connector, "fetch", fake_fetch)
+    reply = chatbot.dispatch("info.arxiv", {"query": "ml"})
+    assert "Paper" in reply
+    assert calls == [("ml", 5)]
+
+
+def test_pubmed_intent_and_dispatch(monkeypatch):
+    monkeypatch.setattr(qwen_intent, "predict", lambda _: None)
+    out = _predict_intent("pubmed cancer research")
+    assert out == {"intent": "info.pubmed", "slots": {"query": "cancer research"}}
+
+    calls = []
+
+    def fake_fetch(query, max_results=5):
+        calls.append((query, max_results))
+        return [{"title": "Study"}]
+
+    monkeypatch.setattr(chatbot.pubmed_connector, "fetch", fake_fetch)
+    reply = chatbot.dispatch("info.pubmed", {"query": "heart"})
+    assert "Study" in reply
+    assert calls == [("heart", 5)]
+
+
+def test_openalex_intent_and_dispatch(monkeypatch):
+    monkeypatch.setattr(qwen_intent, "predict", lambda _: None)
+    out = _predict_intent("openalex reinforcement learning")
+    assert out == {"intent": "info.openalex", "slots": {"query": "reinforcement learning"}}
+
+    calls = []
+
+    def fake_fetch(search, per_page=5):
+        calls.append((search, per_page))
+        return [{"title": "Work"}]
+
+    monkeypatch.setattr(chatbot.openalex_connector, "fetch", fake_fetch)
+    reply = chatbot.dispatch("info.openalex", {"query": "rl"})
+    assert "Work" in reply
+    assert calls == [("rl", 5)]
+
+
+def test_fred_intent_and_dispatch(monkeypatch):
+    monkeypatch.setattr(qwen_intent, "predict", lambda _: None)
+    out = _predict_intent("fred GDP")
+    assert out == {"intent": "info.fred", "slots": {"series_id": "GDP"}}
+
+    calls = []
+
+    def fake_fetch_series(series_id, limit=5):
+        calls.append((series_id, limit))
+        return [{"date": "2024-01-01", "value": "1"}]
+
+    monkeypatch.setattr(chatbot.fred_connector, "fetch_series", fake_fetch_series)
+    reply = chatbot.dispatch("info.fred", {"series_id": "GDP"})
+    assert "2024-01-01" in reply
+    assert calls == [("GDP", 5)]
+
+
+def test_github_intent_and_dispatch(monkeypatch):
+    monkeypatch.setattr(qwen_intent, "predict", lambda _: None)
+    out = _predict_intent("github repo openai/gym")
+    assert out == {"intent": "info.github", "slots": {"owner": "openai", "repo": "gym"}}
+
+    calls = []
+
+    def fake_fetch_repo(owner, repo):
+        calls.append((owner, repo))
+        return {"full_name": f"{owner}/{repo}", "description": "desc"}
+
+    monkeypatch.setattr(chatbot.github_connector, "fetch_repo", fake_fetch_repo)
+    reply = chatbot.dispatch("info.github", {"owner": "openai", "repo": "gym"})
+    assert "openai/gym" in reply
+    assert calls == [("openai", "gym")]


### PR DESCRIPTION
## Summary
- Expand chatbot intro/help to advertise arXiv, PubMed, OpenAlex, FRED and GitHub lookups
- Add dispatch helpers and NLU intent patterns for each connector
- Document connector phrases in chatbot_frontend docs

## Testing
- `pytest tests/test_chatbot_lookup.py -q`
- `pytest tests/test_chatbot_pipeline.py tests/test_chatbot_nlu_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3a9a59608832b8ea81abdf2d37bda