### PR TITLE
Clarify GDELT API usage in chatbot frontend

### DIFF
--- a/src/sentimental_cap_predictor/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/chatbot_frontend.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 from sentimental_cap_predictor.config_llm import get_llm_config
-from sentimental_cap_predictor.llm_providers.qwen_local import QwenLocalProvider
+from sentimental_cap_predictor.llm_providers.qwen_local import (
+    QwenLocalProvider,
+)
 
 SYSTEM_PROMPT = (
     "You are a helpful assistant."
     "\nIf you want me to run a shell command, respond with 'CMD: <command>'."
     "\nFor normal replies, respond without the prefix."
+    "\nGDELT articles should be fetched from "
+    "https://api.gdeltproject.org/api/v2/doc/doc."
+    "\nExample: CMD: curl "
+    '"https://api.gdeltproject.org/api/v2/doc/doc?query=ukraine&'
+    'mode=ArtList&format=json"'
 )
 
 


### PR DESCRIPTION
## Summary
- Specify GDELT articles should come from https://api.gdeltproject.org/api/v2/doc/doc
- Add example curl command in system prompt to demonstrate usage

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot_frontend.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas', 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b4a63f9ee8832b8094b48ed3814e39