### PR TITLE
refactor: use lazy imports in chatbot frontend

### DIFF
--- a/src/sentimental_cap_predictor/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/chatbot_frontend.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import re
-import subprocess
-
 # Heavy dependencies are imported lazily in ``main`` to keep the module light
 # for unit tests and simple command handling.
 
@@ -38,6 +35,9 @@ def handle_command(command: str) -> str:
     headline.  All other commands are executed via the system shell and the
     resulting standard output (or standard error) is returned.
     """
+
+    import re
+    import subprocess
 
     lower = command.lower()
     if "gdelt" in lower or "news" in lower:

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -24,6 +24,6 @@ def test_handle_command_runs_shell(monkeypatch):
         stdout = "ok"
         stderr = ""
 
-    monkeypatch.setattr(cf.subprocess, "run", lambda *a, **k: DummyCompleted())
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: DummyCompleted())
     out = cf.handle_command("echo hi")
     assert out == "ok"


### PR DESCRIPTION
## Summary
- lazy-load `re` and `subprocess` inside `handle_command`
- adjust chatbot frontend tests for new import style

## Testing
- `pytest tests/test_chatbot_frontend.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4c8ebfa94832ba8e1018210f6e6ba