### PR TITLE
refactor: silence config logging on import

### DIFF
--- a/src/sentimental_cap_predictor/config.py
+++ b/src/sentimental_cap_predictor/config.py
@@ -11,7 +11,11 @@ load_dotenv()
 # Paths
 PACKAGE_DIR = Path(__file__).resolve().parent
 PROJ_ROOT = PACKAGE_DIR.parents[1]
-logger.info(f"PROJ_ROOT path is: {PROJ_ROOT}")
+
+
+def log_project_root() -> None:
+    """Log the resolved project root path."""
+    logger.info(f"PROJ_ROOT path is: {PROJ_ROOT}")
 
 DATA_DIR = PROJ_ROOT / "data"
 RAW_DATA_DIR = Path(os.getenv("RAW_DATA_DIR", DATA_DIR / "raw"))
@@ -107,3 +111,7 @@ TICKER_LIST = [ticker.strip() for ticker in TICKER_LIST if ticker.strip()]
 
 if ENABLE_TICKER_LOGS:
     logger.info(f"Final ticker list: {TICKER_LIST}")
+
+
+if __name__ == "__main__":
+    log_project_root()


### PR DESCRIPTION
## Summary
- avoid logging project root when importing configuration

## Testing
- `pytest tests/test_logging_output.py::test_no_logging_on_import -q` *(fails: ModuleNotFoundError: No module named 'newspaper')*
- `python - <<'PY'
import sys, io
sys.path.append('src')
stdout = io.StringIO(); sys_stdout = sys.stdout; sys.stdout = stdout
import sentimental_cap_predictor.config  # noqa: F401
sys.stdout = sys_stdout
print('LOG_OUTPUT:', stdout.getvalue())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b4ca0ce948832b84c1fa4a7e096b76