### PR TITLE
fix: add missing colorama import

### DIFF
--- a/src/sentimental_cap_predictor/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/chatbot_frontend.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 # Heavy dependencies are imported lazily in ``main`` to keep the module light
-# for unit tests and simple command handling.
+# for unit tests and simple command handling. ``colorama`` is a lightweight
+# dependency used to provide coloured prompts for a nicer CLI experience.
+from colorama import Fore, Style, init
+
+# Initialise colour handling for cross-platform compatibility
+init(autoreset=True)
 
 
 def fetch_first_gdelt_article(query: str) -> str:  # pragma: no cover
@@ -64,7 +69,7 @@ def main() -> None:
 
     while True:
         try:
-            user = input("user> ").strip()
+            user = input(f"{Fore.CYAN}user>{Style.RESET_ALL} ").strip()
         except (EOFError, KeyboardInterrupt):
             print()
             break


### PR DESCRIPTION
## Summary
- add colorama import and initialize to support colored CLI prompts
- color REPL prompt to avoid NameError

## Testing
- `PYTHONPATH=src python -m sentimental_cap_predictor.chatbot_frontend <<'EOF'
exit
EOF`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b5d85f062c832bac319f9bf2f14f18