### PR TITLE
feat: enforce strict command planner prompt

### DIFF
--- a/src/sentimental_cap_predictor/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/chatbot_frontend.py
@@ -21,14 +21,14 @@ def fetch_first_gdelt_article(query: str) -> str:  # pragma: no cover
     return ""
 
 SYSTEM_PROMPT = (
-    "You are a helpful assistant."
-    "\nIf you want me to run a shell command, respond with 'CMD: <command>'."
-    "\nFor normal replies, respond without the prefix."
-    "\nGDELT articles should be fetched from "
-    "https://api.gdeltproject.org/api/v2/doc/doc."
-    "\nExample: CMD: curl "
-    '"https://api.gdeltproject.org/api/v2/doc/doc?query=ukraine&'
-    'mode=ArtList&format=json"'
+    "You are a command planner for a terminal application.\n"
+    "Output must be a single line: either\n"
+    "CMD: <command> to run, or one clarifying question.\n"
+    "Do not include code fences, explanations, or extra lines.\n"
+    "Available tools:\n"
+    "  • curl \"<url>\" (defaults: -sSL)\n"
+    "  • gdelt search --query \"<q>\" --limit <n> (default --limit 10)\n"
+    "Before responding, self-check that your output abides by these rules."
 )
 
 


### PR DESCRIPTION
## Summary
- tighten the SYSTEM_PROMPT for the chatbot frontend to operate as a command planner with strict output rules

## Testing
- `pytest` *(fails: Interrupted: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dc65f5e4832ba1bd3b03749b45da