### PR TITLE
Implement GDELT fetch in chatbot frontend and add tests

### DIFF
--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -1,22 +1,76 @@
 import subprocess
+import requests
+import importlib.util
+from pathlib import Path
 
-from sentimental_cap_predictor import chatbot_frontend as cf
+# Import the module directly to avoid triggering package-level side effects
+spec = importlib.util.spec_from_file_location(
+    "chatbot_frontend",
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "sentimental_cap_predictor"
+    / "chatbot_frontend.py",
+)
+cf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cf)
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+def test_fetch_first_gdelt_article(monkeypatch):
+    payload = {
+        "articles": [
+            {"title": "Headline", "url": "http://example.com"}
+        ]
+    }
+
+    def fake_get(url, params, timeout):  # noqa: ANN001
+        assert params["query"] == "NVDA"
+        return DummyResponse(payload)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    text = cf.fetch_first_gdelt_article("NVDA")
+    assert text == "Headline - http://example.com"
 
 
 def test_handle_command_routes_to_gdelt(monkeypatch):
-    called = {}
+    payload = {
+        "articles": [
+            {"title": "Headline", "url": "http://example.com"}
+        ]
+    }
 
-    def fake_fetch(query):  # noqa: ANN001
-        called["query"] = query
-        return "Headline"
+    def fake_get(url, params, timeout):  # noqa: ANN001
+        return DummyResponse(payload)
 
-    monkeypatch.setattr(cf, "fetch_first_gdelt_article", fake_fetch)
+    monkeypatch.setattr(requests, "get", fake_get)
 
     text = cf.handle_command(
         "curl https://api.gdeltproject.org/api/v2/doc/doc?query=NVDA"
     )
-    assert called["query"] == "NVDA"
-    assert text == "Headline"
+    assert text == "Headline - http://example.com"
+
+
+def test_handle_command_fallback(monkeypatch):
+    def fake_get(url, params, timeout):  # noqa: ANN001
+        return DummyResponse({"articles": []})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    text = cf.handle_command(
+        "curl https://api.gdeltproject.org/api/v2/doc/doc?query=NVDA"
+    )
+    assert text == "No news found."
 
 
 def test_handle_command_runs_shell(monkeypatch):


### PR DESCRIPTION
## Summary
- Implement real `fetch_first_gdelt_article` that calls the GDELT API and returns the first article's title and URL
- Add tests for GDELT lookup and `handle_command` paths, including fallback handling

## Testing
- `pytest tests/test_chatbot_frontend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5dc78c548832b98e564f574aef7a7