### PR TITLE
Use handle_command for chatbot frontend command execution

### DIFF
--- a/src/sentimental_cap_predictor/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/chatbot_frontend.py
@@ -111,6 +111,13 @@ def main() -> None:
         {"role": "system", "content": SYSTEM_PROMPT},
     ]
 
+    def run_command(cmd: str) -> str:
+        """Execute ``cmd`` via :func:`handle_command` and display the output."""
+
+        output = handle_command(cmd)
+        print(output)
+        return output
+
     while True:
         try:
             user = input(f"{Fore.CYAN}user>{Style.RESET_ALL} ").strip()
@@ -127,8 +134,7 @@ def main() -> None:
         reply = provider.chat(history)
         command, question = extract_cmd(reply)
         if command:
-            output = handle_command(command)
-            print(output)
+            output = run_command(command)
             history.append({"role": "assistant", "content": output})
             continue
         if question:
@@ -146,8 +152,7 @@ def main() -> None:
         reply = provider.chat(history)
         command, question = extract_cmd(reply)
         if command:
-            output = handle_command(command)
-            print(output)
+            output = run_command(command)
             history.append({"role": "assistant", "content": output})
         elif question:
             print(question)


### PR DESCRIPTION
## Summary
- Execute commands via new `run_command` helper that delegates to module-level `handle_command`
- Print command output so fetched news articles are visible in the REPL

## Testing
- `pytest -q` *(fails: No module named 'pandas')*
- `pytest tests/test_chatbot_frontend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e1f1ccc4832bb27685ad4e5495f1