### PR TITLE
Handle quoted gdelt query options

### DIFF
--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -61,6 +61,25 @@ def test_handle_command_routes_to_gdelt(monkeypatch):
     assert text == "Headline - http://example.com"
 
 
+def test_handle_command_parses_dash_query(monkeypatch):
+    payload = {
+        "articles": [
+            {"title": "Headline", "url": "http://example.com"}
+        ]
+    }
+
+    def fake_get(url, params, timeout):  # noqa: ANN001
+        assert params["query"] == "climate change"
+        return DummyResponse(payload)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    text = cf.handle_command(
+        'gdelt search --query "climate change" --limit 5'
+    )
+    assert text == "Headline - http://example.com"
+
+
 def test_handle_command_fallback(monkeypatch):
     def fake_get(url, params, timeout):  # noqa: ANN001
         return DummyResponse({"articles": []})


### PR DESCRIPTION
## Summary
- Expand `handle_command` to parse both `query=` and `--query` forms, handling quoted multi-word queries
- Add regression test for `gdelt search --query "climate change" --limit 5`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests/test_chatbot_frontend.py::test_handle_command_parses_dash_query -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e386bd48832b89f948229e04832f