### PR TITLE
refactor: centralize command extraction

### DIFF
--- a/src/sentimental_cap_predictor/cmd_utils.py
+++ b/src/sentimental_cap_predictor/cmd_utils.py
@@ -1,0 +1,22 @@
+"""Command parsing helpers for chatbot frontend."""
+
+from __future__ import annotations
+
+
+def extract_cmd(text: str) -> tuple[str | None, str | None]:
+    """Return either a command or a single question from ``text``.
+
+    The function looks for a ``CMD:`` prefix to indicate a shell command. If
+    the response is a lone question, ending with ``?`` and containing no
+    newlines, it is returned as such. When neither pattern matches ``(None,
+    None)`` is returned.
+    """
+
+    import re
+
+    text = text.strip()
+    if match := re.fullmatch(r"CMD:\s*(.+)", text, re.DOTALL):
+        return match.group(1).strip(), None
+    if text.endswith("?") and text.count("?") == 1 and "\n" not in text:
+        return None, text
+    return None, None


### PR DESCRIPTION
## Summary
- pull command extraction into dedicated helper
- use shared `extract_cmd` in chatbot frontend

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot_frontend.py src/sentimental_cap_predictor/cmd_utils.py`
- `pytest tests/test_chatbot_frontend.py::test_retry_on_malformed_output -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4aa0200832baabb020497c96421