### PR TITLE
Handle GDELT request failures in chatbot frontend

### DIFF
--- a/src/sentimental_cap_predictor/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/chatbot_frontend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+import logging
 import requests
 
 # Heavy dependencies are imported lazily in ``main`` to keep the module light
@@ -65,8 +66,9 @@ def fetch_first_gdelt_article(
         if title and link:
             return f"{title} - {link}"
         return title or link
-    except requests.RequestException:
-        return ""
+    except requests.RequestException as exc:
+        logging.exception("GDELT request failed")
+        return f"GDELT request failed: {exc}"
 
 
 SYSTEM_PROMPT = (
@@ -112,7 +114,10 @@ def handle_command(command: str) -> str:
                     break
         if query is None and parts:
             query = parts[-1]
-        return fetch_first_gdelt_article(query) or "No news found."
+        result = fetch_first_gdelt_article(query)
+        if not result:
+            return "No news found."
+        return result
 
     result = subprocess.run(
         command,

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -92,6 +92,28 @@ def test_handle_command_fallback(monkeypatch):
     assert text == "No news found."
 
 
+def test_fetch_first_gdelt_article_error(monkeypatch):
+    def fake_get(url, params, timeout):  # noqa: ANN001
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    text = cf.fetch_first_gdelt_article("NVDA")
+    assert text.startswith("GDELT request failed:")
+
+
+def test_handle_command_reports_network_error(monkeypatch):
+    def fake_get(url, params, timeout):  # noqa: ANN001
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    text = cf.handle_command(
+        "curl https://api.gdeltproject.org/api/v2/doc/doc?query=NVDA"
+    )
+    assert text.startswith("GDELT request failed:")
+
+
 def test_handle_command_runs_shell(monkeypatch):
     class DummyCompleted:
         stdout = "ok"


### PR DESCRIPTION
## Summary
- Log and report GDELT API request failures in `fetch_first_gdelt_article`
- Propagate error messages through `handle_command` for user feedback
- Add regression tests for network failures

## Testing
- `pytest tests/test_chatbot_frontend.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6186ccfdc832b807c0ee100f296ca