### PR TITLE
Refactor FAISS indexer into reusable TextMemory

### DIFF
--- a/src/sentimental_cap_predictor/idea_mining.py
+++ b/src/sentimental_cap_predictor/idea_mining.py
@@ -9,7 +9,7 @@ from typing import List
 import faiss  # type: ignore
 from loguru import logger
 
-from .indexer import MODEL_NAME, embed_texts
+from .memory_indexer import MODEL_NAME, TextMemory
 
 INDEX_PATH = Path("data/papers.index")
 METADATA_PATH = Path("data/papers.json")
@@ -32,7 +32,8 @@ def retrieve_context(query: str, k: int = 5) -> List[dict]:
     index = faiss.read_index(str(INDEX_PATH))
     papers = json.loads(METADATA_PATH.read_text())
 
-    query_vec = embed_texts([query], model_name=MODEL_NAME)
+    memory = TextMemory(model_name=MODEL_NAME)
+    query_vec = memory.embed([query])
     distances, indices = index.search(query_vec, k)
 
     results: List[dict] = []

--- a/src/sentimental_cap_predictor/scheduler.py
+++ b/src/sentimental_cap_predictor/scheduler.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 from loguru import logger
 
 from . import connectors
-from .indexer import build_index
+from .memory_indexer import TextMemory
 from .research.idea_generator import generate_ideas
 
 load_dotenv()
@@ -116,7 +116,12 @@ def index_papers() -> None:
     metadata_path = DATA_DIR / "papers.json"
     metadata_path.write_text(json.dumps(papers, indent=2))
     index_path = DATA_DIR / "papers.index"
-    build_index(papers, index_path)
+    memory = TextMemory()
+    texts = [
+        f"{p.get('title', '')} {p.get('abstract', '')}".strip() for p in papers
+    ]
+    memory.add(texts)
+    memory.save(index_path)
 
     state = _load_state()
     state["papers_indexed"] = datetime.utcnow().isoformat()


### PR DESCRIPTION
## Summary
- rename `indexer` module to `memory_indexer`
- introduce `TextMemory` wrapper class with add/save/load helpers
- update scheduler and idea mining utilities to use `TextMemory`
- adjust tests for new API

## Testing
- `pytest tests/test_indexer_reuse.py -q`
- `pytest -q` *(fails: No module named 'typer', 'sklearn', 'yfinance', 'sqlalchemy', 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68b630585bac832b84e9794881468cff