### PR TITLE
Add memory search command to chatbot frontend

### DIFF
--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -55,6 +55,19 @@ starting a reply with `CMD:` followed by the command string. The runner detects
 these lines, executes the command in a shell, and feeds the captured output back
 into the conversation so the model can continue the dialogue.
 
+### Memory search
+
+The `memory search "<query>"` command loads a local FAISS index of past article
+content and performs a similarity search. The handler returns the titles and
+URLs of the most relevant matches:
+
+```bash
+memory search "climate change policy"
+```
+
+If the memory index (`data/memory.faiss`) or accompanying metadata JSON is not
+found, a message describing the missing resource is returned instead.
+
 ## Connector intents
 
 The chatbot understands simple phrases to pull data from a few external


### PR DESCRIPTION
## Summary
- Extend `handle_command` with a `memory search` branch that loads a FAISS index, embeds the query, runs similarity search and returns matching titles/URLs.
- Document `memory search` usage in `docs/chatbot_frontend.md`.
- Add test verifying memory search retrieval logic.

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/chatbot_frontend.py docs/chatbot_frontend.md tests/test_chatbot_frontend.py`
- `pytest` *(fails: tests require unavailable dependencies)*
- `pytest tests/test_chatbot_frontend.py -k memory_search -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6367060ac832b9d00034816c931a6