### PR TITLE
Persist GDELT article metadata and add FAISS dependency

### DIFF
--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -57,9 +57,11 @@ into the conversation so the model can continue the dialogue.
 
 ### Memory search
 
-The `memory search "<query>"` command loads a local FAISS index of past article
-content and performs a similarity search. The handler returns the titles and
-URLs of the most relevant matches:
+Articles fetched via `gdelt` commands are automatically embedded and appended to
+`data/memory.faiss`, with their titles and URLs recorded in `data/memory.json`.
+The `memory search "<query>"` command loads this index of past article content
+and performs a similarity search. The handler returns the titles and URLs of the
+most relevant matches:
 
 ```bash
 memory search "climate change policy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "accelerate>=0.30,<1",
     "safetensors>=0.4,<1",
     "torch==2.2.2",
+    "faiss-cpu>=1.7,<2",
     "pydantic==2.11.7",
     "prefect==3.4.13",
     "python-dotenv>=1.0,<2",


### PR DESCRIPTION
## Summary
- Persist GDELT article text to FAISS memory and record title/URL metadata
- Document automatic memory persistence and add faiss-cpu to dependencies
- Cover metadata storage in chatbot tests

## Testing
- `pre-commit run --files pyproject.toml docs/chatbot_frontend.md src/sentimental_cap_predictor/llm_core/chatbot_frontend.py tests/test_chatbot_frontend.py` *(fails: command not found)*
- `pytest tests/test_chatbot_frontend.py tests/test_news.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b622a0cfd4832bbd60e53d6e53ed80