### PR TITLE
Add configurable article fetching with novelty and filter support

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -12,13 +12,30 @@ import requests
 from colorama import Fore, Style, init
 
 from sentimental_cap_predictor.data.news import (
-    fetch_first_gdelt_article as _fetch_first_gdelt_article,
+    fetch_article as _fetch_article,
+    FetchArticleSpec,
 )
 
 _MEMORY_INDEX = Path("data/memory.faiss")
 
 # Initialise colour handling for cross-platform compatibility
 init(autoreset=True)
+
+
+def _fetch_first_gdelt_article(
+    query: str,
+    *,
+    prefer_content: bool = True,
+    days: int = 1,
+    max_records: int = 100,
+):
+    spec = FetchArticleSpec(
+        query=query,
+        days=days,
+        max_records=max_records,
+        require_text_accessible=prefer_content,
+    )
+    return _fetch_article(spec)
 
 
 def fetch_first_gdelt_article(

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -19,10 +19,26 @@ class ArticleData:
 # Provide lightweight stand-ins to avoid importing the full package
 dummy_news = types.ModuleType("sentimental_cap_predictor.data.news")
 dummy_news.fetch_first_gdelt_article = lambda *a, **k: None
+
+
+@dataclass
+class FetchArticleSpec:
+    query: str
+    days: int = 1
+    max_records: int = 100
+    must_contain_any: tuple[str, ...] = ()
+    avoid_domains: tuple[str, ...] = ()
+    require_text_accessible: bool = False
+    novelty_against_urls: tuple[str, ...] = ()
+
+
+dummy_news.fetch_article = lambda spec: ArticleData()
+dummy_news.FetchArticleSpec = FetchArticleSpec
 dummy_data = types.ModuleType("sentimental_cap_predictor.data")
 dummy_data.__path__ = []  # mark as package
 dummy_data.news = dummy_news
 sys.modules.setdefault("sentimental_cap_predictor.data", dummy_data)
+sys.modules.setdefault("sentimental_cap_predictor.data.news", dummy_news)
 sys.modules.setdefault("sentimental_cap_predictor.data.news", dummy_news)
 
 


### PR DESCRIPTION
## Summary
- add `FetchArticleSpec` and helper utilities for validating, extracting, and ranking GDELT articles
- introduce `fetch_article` using spec-based filtering and novelty scoring
- update chatbot frontend and tests to use new article fetcher

## Testing
- `pytest tests/test_news.py tests/test_chatbot_frontend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b64557f190832b934b9e5379a5eccc