### PR TITLE
Track seen GDELT articles and boost novel headlines

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -18,6 +18,9 @@ from sentimental_cap_predictor.data.news import (
 
 _MEMORY_INDEX = Path("data/memory.faiss")
 
+_SEEN_URLS: set[str] = set()
+_SEEN_TITLES: set[str] = set()
+
 # Initialise colour handling for cross-platform compatibility
 init(autoreset=True)
 
@@ -34,8 +37,14 @@ def _fetch_first_gdelt_article(
         days=days,
         max_records=max_records,
         require_text_accessible=prefer_content,
+        novelty_against_urls=tuple(_SEEN_URLS),
     )
-    return _fetch_article(spec)
+    article = _fetch_article(spec, seen_titles=_SEEN_TITLES)
+    if article.url:
+        _SEEN_URLS.add(article.url)
+    if article.title:
+        _SEEN_TITLES.add(article.title)
+    return article
 
 
 def fetch_first_gdelt_article(

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -32,7 +32,7 @@ class FetchArticleSpec:
     novelty_against_urls: tuple[str, ...] = ()
 
 
-dummy_news.fetch_article = lambda spec: ArticleData()
+dummy_news.fetch_article = lambda spec, seen_titles=(): ArticleData()
 dummy_news.FetchArticleSpec = FetchArticleSpec
 dummy_data = types.ModuleType("sentimental_cap_predictor.data")
 dummy_data.__path__ = []  # mark as package
@@ -91,6 +91,26 @@ def test_fetch_first_gdelt_article(monkeypatch, tmp_path):
     text = cf.fetch_first_gdelt_article("NVDA")
     assert text == "Body text"
     assert captured["prefer_content"] is True
+
+
+def test_seen_sets_update_and_pass(monkeypatch):
+    monkeypatch.setattr(cf, "_SEEN_URLS", set())
+    monkeypatch.setattr(cf, "_SEEN_TITLES", set())
+
+    captures: list[tuple[str, ...]] = []
+
+    def fake_fetch(spec, seen_titles=()):  # noqa: ANN001
+        captures.append(spec.novelty_against_urls)
+        return ArticleData(title="Headline", url="http://example.com")
+
+    monkeypatch.setattr(cf, "_fetch_article", fake_fetch)
+
+    cf._fetch_first_gdelt_article("NVDA")
+    cf._fetch_first_gdelt_article("NVDA")
+
+    assert captures == [(), ("http://example.com",)]
+    assert cf._SEEN_URLS == {"http://example.com"}
+    assert cf._SEEN_TITLES == {"Headline"}
 
 
 def test_fetch_first_gdelt_article_appends_memory(monkeypatch, tmp_path):

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -254,3 +254,21 @@ def test_fetch_article_applies_filters_and_novelty(monkeypatch):
     )
     article = news.fetch_article(spec)
     assert article.url == "http://new.com/b"
+
+
+def test_fetch_article_title_novelty(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {"title": "Seen headline", "url": "http://old.com/a"},
+            {"title": "Fresh perspective", "url": "http://new.com/b"},
+        ]
+    )
+
+    monkeypatch.setattr(
+        news, "query_gdelt_for_news", lambda q, s, e, *, max_records=100: df
+    )
+    monkeypatch.setattr(news, "extract_article_content", lambda url: "")
+
+    spec = news.FetchArticleSpec(query="q")
+    article = news.fetch_article(spec, seen_titles=("Seen headline",))
+    assert article.url == "http://new.com/b"


### PR DESCRIPTION
## Summary
- Track seen article URLs and titles in the chatbot session and skip repeats
- Rank GDELT candidates with a title-based novelty bonus
- Add tests covering session tracking and headline novelty

## Testing
- `pytest tests/test_chatbot_frontend.py tests/test_news.py::test_fetch_article_applies_filters_and_novelty tests/test_news.py::test_fetch_article_title_novelty -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73a8469b8832b8c03e1ca9765f70b