### PR TITLE
Add GDELT search client with tests

### DIFF
--- a/src/sentimental_cap_predictor/config.py
+++ b/src/sentimental_cap_predictor/config.py
@@ -17,6 +17,7 @@ def log_project_root() -> None:
     """Log the resolved project root path."""
     logger.info(f"PROJ_ROOT path is: {PROJ_ROOT}")
 
+
 DATA_DIR = PROJ_ROOT / "data"
 RAW_DATA_DIR = Path(os.getenv("RAW_DATA_DIR", DATA_DIR / "raw"))
 INTERIM_DATA_DIR = Path(
@@ -33,6 +34,11 @@ TRADER_DIR = PACKAGE_DIR / "trading" / "trader_utils"
 
 REPORTS_DIR = PROJ_ROOT / "reports"
 FIGURES_DIR = REPORTS_DIR / "figures"
+
+# API endpoints
+GDELT_API_URL = os.getenv(
+    "GDELT_API_URL", "https://api.gdeltproject.org/api/v2/doc/doc"
+)
 
 # Model hyperparameters
 LEARNING_RATE = float(os.getenv("LEARNING_RATE", 0.001))

--- a/src/sentimental_cap_predictor/news/__init__.py
+++ b/src/sentimental_cap_predictor/news/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for interacting with news APIs."""
+
+from .gdelt_client import search_gdelt
+
+__all__ = ["search_gdelt"]

--- a/src/sentimental_cap_predictor/news/gdelt_client.py
+++ b/src/sentimental_cap_predictor/news/gdelt_client.py
@@ -1,0 +1,65 @@
+"""Client helpers for querying the GDELT news API."""
+
+from __future__ import annotations
+
+import requests
+
+from sentimental_cap_predictor.config import GDELT_API_URL
+
+
+def search_gdelt(query: str, max_results: int = 3) -> list[dict]:
+    """Search the GDELT ``doc`` endpoint for ``query``.
+
+    Parameters
+    ----------
+    query:
+        Search string passed to GDELT.
+    max_results:
+        Maximum number of articles to return.  The value is also forwarded to
+        the API via the ``maxrecords`` parameter.
+
+    Returns
+    -------
+    list[dict]
+        A list of dictionaries with keys ``title``, ``url``, ``source`` and
+        ``pubdate``.  An empty list is returned when the request fails or the
+        response payload cannot be parsed.
+    """
+
+    params = {
+        "query": query,
+        "format": "json",
+        "mode": "artlist",
+        "maxrecords": max_results,
+    }
+    try:
+        response = requests.get(GDELT_API_URL, params=params, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException:
+        return []
+
+    try:
+        data = response.json()
+    except ValueError:
+        return []
+
+    articles = data.get("articles", [])
+    results: list[dict] = []
+    for article in articles[:max_results]:
+        results.append(
+            {
+                "title": article.get("title", ""),
+                "url": article.get("url", ""),
+                "source": (
+                    article.get("sourceCommonName")
+                    or article.get(
+                        "source",
+                        "",
+                    )
+                ),
+                "pubdate": (
+                    article.get("seendate") or article.get("publishedDate", "")
+                ),
+            }
+        )
+    return results

--- a/tests/test_gdelt_client.py
+++ b/tests/test_gdelt_client.py
@@ -1,0 +1,117 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import requests
+
+# Create lightweight package stubs to avoid heavy imports
+# from sentimental_cap_predictor
+pkg = types.ModuleType("sentimental_cap_predictor")
+pkg.__path__ = []
+news_pkg = types.ModuleType("sentimental_cap_predictor.news")
+news_pkg.__path__ = []
+sys.modules.setdefault("sentimental_cap_predictor", pkg)
+sys.modules.setdefault("sentimental_cap_predictor.news", news_pkg)
+
+# Load configuration module
+config_spec = importlib.util.spec_from_file_location(
+    "sentimental_cap_predictor.config",
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "sentimental_cap_predictor"
+    / "config.py",
+)
+config = importlib.util.module_from_spec(config_spec)
+sys.modules["sentimental_cap_predictor.config"] = config
+config_spec.loader.exec_module(config)
+
+# Load GDELT client module
+client_spec = importlib.util.spec_from_file_location(
+    "sentimental_cap_predictor.news.gdelt_client",
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "sentimental_cap_predictor"
+    / "news"
+    / "gdelt_client.py",
+)
+gdelt_client = importlib.util.module_from_spec(client_spec)
+sys.modules["sentimental_cap_predictor.news.gdelt_client"] = gdelt_client
+client_spec.loader.exec_module(gdelt_client)
+
+search_gdelt = gdelt_client.search_gdelt
+GDELT_API_URL = config.GDELT_API_URL
+
+
+def test_search_gdelt_parses_response(monkeypatch):
+    payload = {
+        "articles": [
+            {
+                "title": "Example",
+                "url": "http://ex",
+                "source": "Feed",
+                "seendate": "20240101",
+            }
+        ]
+    }
+
+    class DummyResponse:
+        def json(self):
+            return payload
+
+        def raise_for_status(self):  # pragma: no cover - no-op
+            pass
+
+    captured = {}
+
+    def fake_get(url, params, timeout):  # noqa: ANN001
+        captured["url"] = url
+        captured["params"] = params
+        return DummyResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    results = search_gdelt("nvda")
+    assert results == [
+        {
+            "title": "Example",
+            "url": "http://ex",
+            "source": "Feed",
+            "pubdate": "20240101",
+        }
+    ]
+    assert captured["url"] == GDELT_API_URL
+    assert captured["params"]["maxrecords"] == 3
+
+
+def test_search_gdelt_default_limit(monkeypatch):
+    payload = {
+        "articles": [
+            {"title": str(i), "url": str(i), "source": "s", "seendate": "d"}
+            for i in range(5)
+        ]
+    }
+
+    class DummyResponse:
+        def json(self):
+            return payload
+
+        def raise_for_status(self):  # pragma: no cover - no-op
+            pass
+
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda url, params, timeout: DummyResponse(),  # noqa: ANN001
+    )
+
+    results = search_gdelt("test")
+    assert len(results) == 3
+
+
+def test_search_gdelt_handles_errors(monkeypatch):
+    def fake_get(url, params, timeout):  # noqa: ANN001
+        raise requests.RequestException
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert search_gdelt("nvda") == []


### PR DESCRIPTION
## Summary
- add configuration constant for GDELT API URL
- implement `search_gdelt` for querying GDELT doc endpoint with error handling
- unit tests checking parsing, default limit and error handling

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/news/__init__.py src/sentimental_cap_predictor/news/gdelt_client.py src/sentimental_cap_predictor/config.py tests/test_gdelt_client.py`
- `pytest tests/test_gdelt_client.py -q`
- `pytest -q` *(fails: 36 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b741e6b748832b8d441ab56bada5d5