### PR TITLE
Add Typer-based news CLI and tests

### DIFF
--- a/src/sentimental_cap_predictor/news/cli.py
+++ b/src/sentimental_cap_predictor/news/cli.py
@@ -1,0 +1,105 @@
+"""Command line utilities for news related tasks."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Optional
+
+import typer
+
+from .article_reader import analyze as analyze_text
+from .article_reader import chunk as chunk_text
+from .article_reader import extract_main, fetch_html, strip_ads
+from .article_reader import summarize as summarize_text
+from .article_reader import translate as translate_text
+from .gdelt_client import search_gdelt
+
+
+class TranslateMode(str, Enum):
+    off = "off"
+    auto = "auto"
+    en = "en"
+
+
+app = typer.Typer(help="News utilities")
+
+
+@app.command("fetch-gdelt")
+def fetch_gdelt_command(
+    query: str = typer.Option(
+        ...,
+        "--query",
+        "-q",
+        help="Search query for GDELT.",
+    ),
+    max_results: int = typer.Option(
+        3, "--max", "-m", help="Maximum number of articles to return."
+    ),
+) -> None:
+    """Fetch articles from the GDELT API and print as JSON."""
+    articles = search_gdelt(query=query, max_results=max_results)
+    typer.echo(json.dumps(articles))
+
+
+@app.command("read")
+def read_command(
+    url: str = typer.Option(..., "--url", "-u", help="Article URL to fetch."),
+    summarize: bool = typer.Option(
+        False, "--summarize", help="Return a short summary."
+    ),
+    analyze: bool = typer.Option(
+        False, "--analyze", help="Return basic text analysis."
+    ),
+    chunks: Optional[int] = typer.Option(
+        None, "--chunks", help="Split text into chunks of this many tokens."
+    ),
+    overlap: int = typer.Option(
+        0, "--overlap", help="Number of overlapping tokens between chunks."
+    ),
+    translate: TranslateMode = typer.Option(
+        TranslateMode.off,
+        "--translate",
+        help="Translation mode: off, auto or en.",
+    ),
+) -> None:
+    """Read an article and optionally process it."""
+    html = fetch_html(url)
+    text = strip_ads(extract_main(html, url=url))
+    original_text = text
+
+    analysis = None
+    if analyze or translate == TranslateMode.auto:
+        analysis = analyze_text(text)
+
+    if translate == TranslateMode.en:
+        text = translate_text(text, "en")
+    elif translate == TranslateMode.auto and analysis:
+        if analysis.get("lang") != "en":
+            text = translate_text(text, "en")
+
+    should_process = any(
+        [
+            summarize,
+            analyze,
+            chunks is not None,
+            translate != TranslateMode.off,
+        ]
+    )
+    if should_process:
+        result: dict[str, object] = {"text": text}
+        if translate != TranslateMode.off and text != original_text:
+            result["original_text"] = original_text
+        if summarize:
+            result["summary"] = summarize_text(text)
+        if analyze:
+            result["analysis"] = analysis
+        if chunks is not None:
+            result["chunks"] = chunk_text(text, chunks, overlap)
+        typer.echo(json.dumps(result))
+    else:
+        typer.echo(text)
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_news_cli.py
+++ b/tests/test_news_cli.py
@@ -1,0 +1,128 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+# Load CLI module without importing the full package
+dummy_pkg = types.ModuleType("sentimental_cap_predictor")
+dummy_pkg.__path__ = []
+sys.modules.setdefault("sentimental_cap_predictor", dummy_pkg)
+
+dummy_news_pkg = types.ModuleType("sentimental_cap_predictor.news")
+dummy_news_pkg.__path__ = [
+    str(
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sentimental_cap_predictor"
+        / "news"
+    )
+]
+sys.modules.setdefault("sentimental_cap_predictor.news", dummy_news_pkg)
+dummy_pkg.news = dummy_news_pkg
+
+dummy_config = types.ModuleType("sentimental_cap_predictor.config")
+dummy_config.GDELT_API_URL = "https://example.com"
+sys.modules.setdefault("sentimental_cap_predictor.config", dummy_config)
+dummy_pkg.config = dummy_config
+
+module_name = "sentimental_cap_predictor.news.cli"
+spec = importlib.util.spec_from_file_location(
+    module_name,
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "sentimental_cap_predictor"
+    / "news"
+    / "cli.py",
+)
+cli = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = cli
+spec.loader.exec_module(cli)
+dummy_news_pkg.cli = cli
+
+app = cli.app
+
+
+def test_fetch_gdelt_cli(monkeypatch):
+    runner = CliRunner()
+
+    def fake_search_gdelt(query, max_results):  # noqa: ANN001
+        assert query == "NVDA"
+        assert max_results == 2
+        return [
+            {
+                "title": "Example",
+                "url": "http://e",
+                "source": "Feed",
+                "pubdate": "2024",
+            }
+        ]
+
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.search_gdelt",
+        fake_search_gdelt,
+    )
+
+    result = runner.invoke(
+        app,
+        ["fetch-gdelt", "--query", "NVDA", "--max", "2"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout.strip())
+    assert data[0]["title"] == "Example"
+
+
+def test_read_cli(monkeypatch):
+    runner = CliRunner()
+
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.fetch_html",
+        lambda url: "<html></html>",
+    )
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.extract_main",
+        lambda html, url=None: "body",
+    )
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.analyze_text",
+        lambda text: {"lang": "en", "word_count": 1},
+    )
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.summarize_text",
+        lambda text: "summary",
+    )
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.chunk_text",
+        lambda text, max_tokens, overlap: ["chunk"],
+    )
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.translate_text",
+        lambda text, target_lang: "translated",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "read",
+            "--url",
+            "http://example.com",
+            "--summarize",
+            "--analyze",
+            "--chunks",
+            "5",
+            "--overlap",
+            "1",
+            "--translate",
+            "en",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout.strip())
+    assert data["text"] == "translated"
+    assert data["summary"] == "summary"
+    assert data["analysis"]["lang"] == "en"
+    assert data["chunks"] == ["chunk"]


### PR DESCRIPTION
## Summary
- add `news/cli.py` with Typer commands to fetch GDELT articles and read articles with optional processing
- support summarization, analysis, chunking, and translation modes in the `read` command
- add CLI tests for fetching GDELT results and reading articles

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/news/cli.py tests/test_news_cli.py`
- `pytest tests/test_news_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b746530170832b99426a2c0e064c6d