### PR TITLE
Add news CLI routing in chatbot frontend

### DIFF
--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -70,6 +70,19 @@ memory search "climate change policy"
 If the memory index (`data/memory.faiss`) or accompanying metadata JSON is not
 found, a message describing the missing resource is returned instead.
 
+### News commands
+
+Utilities from the news CLI can be accessed through `CMD:` directives:
+
+```bash
+CMD: news.fetch_gdelt --query "<terms>" --max 1
+CMD: news.read --url "<article_url>" --summarize --analyze --chunks 1000
+```
+
+The first command returns matching GDELT articles as JSON. The second retrieves
+an article, summarises it, performs a basic analysis and optionally chunks the
+text for further processing.
+
 ## Connector intents
 
 The chatbot understands simple phrases to pull data from a few external

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,6 +99,15 @@ python -m sentimental_cap_predictor.llm_core.chatbot \
     --experimental-model mistralai/Mistral-7B-Instruct-v0.2
 ```
 
+## News utilities
+
+Basic news helpers are available through the chatbot's command interface:
+
+```bash
+CMD: news.fetch_gdelt --query "<terms>" --max 1
+CMD: news.read --url "<article_url>" --summarize --analyze --chunks 1000
+```
+
 ## GitHub Repository Data
 
 Utilities that pull information from the GitHub API can optionally use a


### PR DESCRIPTION
## Summary
- extend chatbot `handle_command` to route `news.fetch_gdelt` and `news.read`
- document news CLI usage examples
- add tests for new command parsing

## Testing
- `pre-commit run --files docs/chatbot_frontend.md docs/cli.md src/sentimental_cap_predictor/llm_core/chatbot_frontend.py tests/test_chatbot_frontend.py`
- `pytest tests/test_chatbot_frontend.py tests/test_news_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b74ad9dcac832bb3c40aebd1f80a85