### PR TITLE
Fix missing seen_titles variable in news article ranking

### DIFF
--- a/src/sentimental_cap_predictor/data/news.py
+++ b/src/sentimental_cap_predictor/data/news.py
@@ -238,6 +238,7 @@ def title_novelty(title: str, seen_titles: Iterable[str]) -> float:
 def rank_candidates(
     candidates: list[dict],
     spec: FetchArticleSpec,
+    seen_titles: Iterable[str] = (),
 ) -> list[dict]:
     """Rank candidates prioritising accessible text and novelty."""
 
@@ -287,7 +288,7 @@ def fetch_article(
     if not candidates:
         raise RuntimeError("No candidate articles matched filters")
 
-    for candidate in rank_candidates(candidates, spec):
+    for candidate in rank_candidates(candidates, spec, seen_titles):
         if candidate.get("content"):
             return ArticleData(
                 title=candidate["title"],


### PR DESCRIPTION
## Summary
- pass seen_titles when ranking candidate articles
- allow rank_candidates to accept seen_titles list for novelty scoring

## Testing
- `pytest` *(fails: ModuleNotFoundError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7546661ec832ba3fc1c87154f6c38