### PR TITLE
Handle bare ticker commands via GDELT

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -295,6 +295,13 @@ def handle_command(command: str) -> str:
             )
         return buf.getvalue().strip()
 
+    # Treat single bare words without a matching executable as GDELT queries.
+    import shutil
+
+    stripped = command.strip()
+    if " " not in stripped and not shutil.which(stripped):
+        return fetch_first_gdelt_article(stripped)
+
     if "gdelt" in lower or "news" in lower:
         parts = shlex.split(command)
         query: str | None = None

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -238,6 +238,21 @@ def test_handle_command_parses_options(monkeypatch):
     assert captured["max_records"] == 5
 
 
+def test_handle_command_plain_word(monkeypatch):
+    monkeypatch.setattr(
+        cf,
+        "_fetch_first_gdelt_article",
+        lambda query, *, prefer_content, days=1, max_records=100: ArticleData(
+            title="Headline",
+            url="http://example.com",
+            content="Body text",
+        ),
+    )
+
+    text = cf.handle_command("NVDA")
+    assert text == "Body text"
+
+
 def test_handle_command_fallback(monkeypatch):
     monkeypatch.setattr(
         cf,


### PR DESCRIPTION
## Summary
- treat single-word commands without executables as GDELT article queries
- cover bare ticker queries with a unit test

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/chatbot_frontend.py tests/test_chatbot_frontend.py`
- `pytest tests/test_chatbot_frontend.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75609f224832bbd6b9e9bd00a532e