### PR TITLE
Add configurable max tokens default for local Qwen provider

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -368,7 +368,9 @@ def main() -> None:
 
     config = get_llm_config()
     provider = QwenLocalProvider(
-        model_path=config.model_path, temperature=config.temperature
+        model_path=config.model_path,
+        temperature=config.temperature,
+        max_new_tokens=config.max_new_tokens,
     )
     history: list[dict[str, str]] = [
         {"role": "system", "content": SYSTEM_PROMPT},

--- a/src/sentimental_cap_predictor/llm_core/chatbot_nlu/qwen_intent.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_nlu/qwen_intent.py
@@ -64,7 +64,11 @@ def call_qwen(utterance: str) -> str:
 
         cfg = get_llm_config()
         # Use deterministic settings for intent classification
-        _LOCAL_PROVIDER = QwenLocalProvider(model_path=cfg.model_path, temperature=0.0)
+        _LOCAL_PROVIDER = QwenLocalProvider(
+            model_path=cfg.model_path,
+            temperature=0.0,
+            max_new_tokens=cfg.max_new_tokens,
+        )
 
     messages = [
         {"role": "system", "content": SYSTEM},

--- a/src/sentimental_cap_predictor/llm_core/config_llm.py
+++ b/src/sentimental_cap_predictor/llm_core/config_llm.py
@@ -16,6 +16,7 @@ class LLMConfig:
 
     model_path: str
     temperature: float
+    max_new_tokens: int = 512
 
 
 def get_llm_config() -> LLMConfig:
@@ -23,4 +24,9 @@ def get_llm_config() -> LLMConfig:
 
     model_path = os.getenv("QWEN_MODEL_PATH", "Qwen/Qwen2-1.5B-Instruct")
     temperature = float(os.getenv("LLM_TEMPERATURE", 0.7))
-    return LLMConfig(model_path=model_path, temperature=temperature)
+    max_new_tokens = int(os.getenv("LLM_MAX_NEW_TOKENS", 512))
+    return LLMConfig(
+        model_path=model_path,
+        temperature=temperature,
+        max_new_tokens=max_new_tokens,
+    )

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -324,7 +324,9 @@ def test_retry_on_malformed_output(monkeypatch):
         sys.modules,
         "sentimental_cap_predictor.llm_core.config_llm",
         SimpleNamespace(
-            get_llm_config=lambda: SimpleNamespace(model_path="", temperature=0.0)
+            get_llm_config=lambda: SimpleNamespace(
+                model_path="", temperature=0.0, max_new_tokens=512
+            )
         ),
     )
     monkeypatch.setitem(


### PR DESCRIPTION
## Summary
- allow QwenLocalProvider to default `max_new_tokens` and compute `max_length`
- expose `LLM_MAX_NEW_TOKENS` via LLMConfig and wire through Qwen provider usage
- update chatbot frontend test to match new config

## Testing
- `pytest tests/test_chatbot_frontend.py::test_retry_on_malformed_output -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b75c96872c832b9ad25788261c83ca