### PR TITLE
Tie Qwen model weights before dispatch

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
+++ b/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
@@ -23,6 +23,7 @@ class QwenLocalProvider(LLMProvider):
         config = AutoConfig.from_pretrained(model_path)
         with init_empty_weights():
             model = AutoModelForCausalLM.from_config(config)
+        model.tie_weights()
         self.model = load_checkpoint_and_dispatch(
             model, model_path, device_map="auto"
         )


### PR DESCRIPTION
## Summary
- tie Qwen model weights before checkpoint dispatch to avoid untied weight warning

## Testing
- `python` stub script instantiating `QwenLocalProvider` shows no untied-weights warning
- `pytest` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68b76129eef8832baed616597f07a0dc