### PR TITLE
Handle Qwen weights via snapshot_download

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ Run `--help` with any module for detailed options.
 ## Qwen Frontend and `CMD:` Protocol
 
 The project includes a lightweight frontend that chats with a **local** Qwen
-model and supports a simple command protocol. Download a Qwen checkpoint from
-Hugging Face and set `QWEN_MODEL_PATH` to its directory (defaults to
-`Qwen/Qwen2-1.5B-Instruct`). If the model does not fit entirely in GPU or CPU
-memory, set `QWEN_OFFLOAD_FOLDER` to a directory where the remaining weights can
-be offloaded. For convenience, alias the module and then run the chatbot:
+model and supports a simple command protocol. Set `QWEN_MODEL_PATH` to either a
+directory containing the model weights or a Hugging Face repository name. When
+a repository name is provided the weights are downloaded locally using
+`huggingface_hub.snapshot_download` (defaults to `Qwen/Qwen2-1.5B-Instruct`). If
+the model does not fit entirely in GPU or CPU memory, set
+`QWEN_OFFLOAD_FOLDER` to a directory where the remaining weights can be
+offloaded. For convenience, alias the module and then run the chatbot:
 
 ```bash
 alias capbot="python -m sentimental_cap_predictor.llm_core.chatbot"

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -1,0 +1,16 @@
+# Qwen Model Weights
+
+The Qwen chatbot requires access to the model weights on the local filesystem.
+Provide the location via the `QWEN_MODEL_PATH` environment variable.
+
+## Supplying weights
+
+- **Local path** – Set `QWEN_MODEL_PATH` to a directory containing the
+  checkpoint files.
+- **Hugging Face repo** – Set `QWEN_MODEL_PATH` to a repository name. The
+  weights are downloaded with `huggingface_hub.snapshot_download` before the
+  model is loaded.
+
+Optional: set `QWEN_OFFLOAD_FOLDER` to a directory for weights that cannot fit
+into GPU/CPU memory.
+


### PR DESCRIPTION
## Summary
- Load Qwen checkpoints from a local path or auto-download from Hugging Face
- Document how to provide Qwen weights

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py README.md configuration/README.md`
- `pytest` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b7655d2854832ba1c624a14de19bf7