### PR TITLE
fix(qwen): preserve model path string

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
+++ b/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
@@ -43,11 +43,13 @@ class QwenLocalProvider(LLMProvider):
         self.temperature = temperature
         self.max_new_tokens = max_new_tokens
 
-        model_path = Path(model_path)
-        if model_path.exists():
-            checkpoint_path = str(model_path)
+        local_model_path = Path(model_path)
+        if local_model_path.exists():
+            checkpoint_path = model_path
         else:
-            checkpoint_path = snapshot_download(repo_id=str(model_path))
+            checkpoint_path = snapshot_download(
+                repo_id=local_model_path.as_posix(),
+            )
 
         self.tokenizer = AutoTokenizer.from_pretrained(checkpoint_path)
         config = AutoConfig.from_pretrained(checkpoint_path)


### PR DESCRIPTION
## Summary
- preserve original `model_path` string when checking for local Qwen checkpoints
- ensure `snapshot_download` receives a POSIX-style path

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_68b766c32c08832b9b2195b7b449a099