### PR TITLE
Fix QwenLocalProvider debug print

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
+++ b/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
@@ -51,6 +51,12 @@ class QwenLocalProvider(LLMProvider):
                 repo_id=local_model_path.as_posix(),
             )
 
+        # Debug print to show the resolved checkpoint path. The previous
+        # implementation attempted to reference ``model_id`` which does not
+        # exist in this context. Use ``checkpoint_path`` instead so the
+        # message reflects the actual path used to load the model weights.
+        print(f"Using checkpoint at: {checkpoint_path}")
+
         self.tokenizer = AutoTokenizer.from_pretrained(checkpoint_path)
         config = AutoConfig.from_pretrained(checkpoint_path)
         with init_empty_weights():


### PR DESCRIPTION
## Summary
- show resolved checkpoint path in QwenLocalProvider

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py`

------
https://chatgpt.com/codex/tasks/task_e_68b76a9553e0832b83a46468327dd4f6