### PR TITLE
Simplify Qwen checkpoint debug message

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
+++ b/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
@@ -51,10 +51,8 @@ class QwenLocalProvider(LLMProvider):
                 repo_id=local_model_path.as_posix(),
             )
 
-        # Debug print to show the resolved checkpoint path. The previous
-        # implementation attempted to reference ``model_id`` which does not
-        # exist in this context. Use ``checkpoint_path`` instead so the
-        # message reflects the actual path used to load the model weights.
+        # Debug print to show the resolved checkpoint path used to load the
+        # model weights.
         print(f"Using checkpoint at: {checkpoint_path}")
 
         self.tokenizer = AutoTokenizer.from_pretrained(checkpoint_path)


### PR DESCRIPTION
## Summary
- clarify checkpoint debug print in Qwen provider

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b76bb8a0e8832b98003ec47b860178