### PR TITLE
feat: auto-create qwen offload directory

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/config_llm.py
+++ b/src/sentimental_cap_predictor/llm_core/config_llm.py
@@ -17,6 +17,9 @@ class LLMConfig:
     model_path: str
     temperature: float
     max_new_tokens: int = 512
+    # Optional directory used by ``accelerate`` to offload model weights. If
+    # ``None`` a directory named "offload" inside the model checkpoint is used
+    # automatically.
     offload_folder: str | None = None
 
 


### PR DESCRIPTION
## Summary
- create an offload directory automatically when loading local Qwen model
- document offload folder behaviour in `LLMConfig`

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py src/sentimental_cap_predictor/llm_core/config_llm.py`
- `pytest tests/test_qwen_local_provider.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b760b86830832b99c904f982b6a844