### PR TITLE
Add device_map and dtype defaults for Qwen local model

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
+++ b/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
@@ -22,6 +22,8 @@ class QwenLocalProvider(LLMProvider):
         temperature: float,
         max_new_tokens: int = 512,
         offload_folder: str | None = None,
+        device_map: str | dict | None = "auto",
+        dtype: str | torch.dtype | None = "auto",
     ) -> None:
         """Create a provider backed by a local Qwen model.
 
@@ -39,6 +41,12 @@ class QwenLocalProvider(LLMProvider):
             full model cannot fit in device memory. If ``None`` a subdirectory
             named ``"offload"`` inside the resolved checkpoint directory is
             created and used automatically.
+        device_map:
+            Device placement for the model. Passed directly to
+            :func:`load_checkpoint_and_dispatch`.
+        dtype:
+            Data type used when loading the model weights. Passed directly to
+            :func:`load_checkpoint_and_dispatch`.
         """
 
         self.temperature = temperature
@@ -73,9 +81,9 @@ class QwenLocalProvider(LLMProvider):
         self.model = load_checkpoint_and_dispatch(
             model,
             checkpoint=checkpoint_path,
-            device_map=prefs["device_map"],
+            device_map=device_map,
             offload_folder=str(offload_dir),
-            dtype=prefs["dtype"],
+            dtype=dtype,
         )
         self.model.eval()
 


### PR DESCRIPTION
## Summary
- add `device_map` and `dtype` parameters with safe defaults for QwenLocalProvider
- document new parameters and use them when dispatching the checkpoint

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py`
- `pytest` (fails: 38 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68b78ab48de0832b97108d0565bbb9a1