### PR TITLE
fix: remove undefined-name bugs in Qwen provider and related code

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
+++ b/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
@@ -62,9 +62,6 @@ class QwenLocalProvider(LLMProvider):
             )
 
         self.model_id = checkpoint_path
-        # Debug print to show the resolved checkpoint path used to load the
-        # model weights.
-        print(f"Using checkpoint at: {self.model_id}")
 
         self.tokenizer = AutoTokenizer.from_pretrained(checkpoint_path)
         config = AutoConfig.from_pretrained(checkpoint_path)
@@ -82,12 +79,9 @@ class QwenLocalProvider(LLMProvider):
         # Normalize dtype: allow "auto" string, torch.dtype, or None
         _dtype = None
         if dtype is not None:
-            if isinstance(dtype, str):
-                if dtype.lower() == "auto":
-                    _dtype = None
-                else:
-                    _dtype = getattr(torch, dtype, None)
-            else:
+            if isinstance(dtype, str) and dtype.lower() != "auto":
+                _dtype = getattr(torch, dtype, None)
+            elif not isinstance(dtype, str):
                 _dtype = dtype
 
         self.model = load_checkpoint_and_dispatch(
@@ -98,12 +92,6 @@ class QwenLocalProvider(LLMProvider):
             dtype=_dtype,
         )
         self.model.eval()
-
-        # Safe optional debug (or remove it entirely)
-        print(
-            f"[runtime] model={self.model_id} device_map={device_map} "
-            f"dtype={_dtype} offload={offload_dir}"
-        )
 
     def chat(self, messages: List[ChatMessage], **kwargs: Any) -> str:
         """Return the model's response to a list of chat messages."""


### PR DESCRIPTION
## Summary
- sanitize QwenLocalProvider to rely on `self.model_id` and normalize `dtype`
- drop leftover runtime debug log referencing undefined variables

## Testing
- `python -m ruff check src --select F821`
- `python -m py_compile $(git ls-files 'src/**/*.py')`
- `PYTHONPATH=src python -m sentimental_cap_predictor.llm_core.chatbot_frontend` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68b798d4a98c832ba9e8503d784bcad7