### PR TITLE
fix: report runtime info with valid names

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
+++ b/src/sentimental_cap_predictor/llm_core/llm_providers/qwen_local.py
@@ -93,6 +93,11 @@ class QwenLocalProvider(LLMProvider):
         )
         self.model.eval()
 
+        print(
+            f"[runtime] model={self.model_id} device_map={device_map} "
+            f"dtype={_dtype} offload={offload_dir}"
+        )
+
     def chat(self, messages: List[ChatMessage], **kwargs: Any) -> str:
         """Return the model's response to a list of chat messages."""
 


### PR DESCRIPTION
## Summary
- print QwenLocalProvider runtime info using in-scope variables

## Testing
- `ruff check src --select F821,E999` *(fails: Rule `E999` was removed and cannot be selected)*
- `PYENV_VERSION=3.11.12 ruff check src --select F821`
- `PYENV_VERSION=3.11.12 python -m py_compile $(git ls-files 'src/**/*.py')`
- `PYENV_VERSION=3.11.12 PYTHONPATH=src python -m sentimental_cap_predictor.llm_core.chatbot_frontend` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68ba4089a2e4832b851b0b5d1b57616d