### PR TITLE
Restrict package discovery to project package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cap-predictor"
 version = "0.1.0"
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "pandas>=2.0,<3",
     "numpy>=1.25,<2",
@@ -45,6 +45,7 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+include = ["sentimental_cap_predictor*"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary
- broaden supported Python versions to allow Python 3.12
- restrict setuptools package discovery to the `sentimental_cap_predictor` namespace to avoid stray top-level packages

## Testing
- `pre-commit run --files pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_e_68ba4f514684832baa57077b644005d7