### PR TITLE
Use env-based QwenLocalProvider

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -400,10 +400,8 @@ def main() -> None:
 
     config = get_llm_config()
     provider = QwenLocalProvider(
-        model_path=config.model_path,
         temperature=config.temperature,
         max_new_tokens=config.max_new_tokens,
-        offload_folder=getattr(config, "offload_folder", None),
     )
     history: list[dict[str, str]] = [
         {"role": "system", "content": SYSTEM_PROMPT},


### PR DESCRIPTION
## Summary
- streamline chatbot frontend's QwenLocalProvider setup to rely on environment variables for model path and device mapping

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/chatbot_frontend.py`
- `PYENV_VERSION=3.11.12 pytest tests/test_chatbot_frontend.py -k test_retry_on_malformed_output -q`


------
https://chatgpt.com/codex/tasks/task_e_68bafd9b8d9c832bad7a5ca125bba97e