### PR TITLE
Handle non-JSON GDELT responses

### DIFF
--- a/src/sentimental_cap_predictor/data/news.py
+++ b/src/sentimental_cap_predictor/data/news.py
@@ -114,10 +114,17 @@ def query_gdelt_for_news(
         "enddatetime": end_date,
         "maxrecords": max_records,
         "format": "json",
-    }
+    }    
     response = requests.get(url, params=params, timeout=30)
     response.raise_for_status()
-    data = response.json()
+    try:
+        data = response.json()
+    except (requests.exceptions.JSONDecodeError, ValueError) as exc:  # pragma: no cover - depends on requests
+        text = getattr(response, "text", "")
+        msg = f"Failed to parse GDELT response as JSON: {exc}"
+        if text:
+            msg += f" Response text: {text}"
+        raise RuntimeError(msg) from exc
     articles = data.get("articles", [])
     return pd.DataFrame(articles)
 


### PR DESCRIPTION
## Summary
- handle JSON parsing errors when querying GDELT by raising a descriptive RuntimeError
- add unit test ensuring non-JSON responses are surfaced clearly

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_news.py::test_query_gdelt_for_news_uses_timeout tests/test_news.py::test_query_gdelt_for_news_handles_timeout tests/test_news.py::test_query_gdelt_for_news_non_json -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc5487c99c832bb62dd1fc271b6763