### PR TITLE
Handle runtime errors fetching GDELT articles

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -97,8 +97,10 @@ def fetch_first_gdelt_article(
         article = _fetch_first_gdelt_article(
             query, prefer_content=True, days=days, max_records=limit
         )
-    except requests.RequestException as exc:  # pragma: no cover
-        return f"GDELT request failed: {exc}"
+    except (requests.RequestException, RuntimeError, ValueError) as exc:  # pragma: no cover
+        if isinstance(exc, requests.RequestException):
+            return f"GDELT request failed: {exc}"
+        return "No readable article found"
 
     if article.title or article.url:
         entry = {"title": article.title, "url": article.url}

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -305,6 +305,16 @@ def test_fetch_first_gdelt_article_error(monkeypatch):
     assert text.startswith("GDELT request failed:")
 
 
+def test_fetch_first_gdelt_article_runtime_error(monkeypatch):
+    def fake_fetch(spec, seen_titles=()):  # noqa: ANN001
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cf, "_fetch_article", fake_fetch)
+
+    text = cf.fetch_first_gdelt_article("NVDA")
+    assert text == "No readable article found"
+
+
 def test_handle_command_reports_network_error(monkeypatch):
     def fake_fetch(query, *, prefer_content, days=1, max_records=100):  # noqa: ANN001
         raise requests.RequestException("boom")


### PR DESCRIPTION
## Summary
- Catch `RuntimeError` and `ValueError` when retrieving GDELT articles
- Return a friendly message for runtime failures instead of propagating
- Add regression test ensuring runtime errors from `fetch_article` yield the friendly message

## Testing
- `PYENV_VERSION=3.11.12 pytest tests/test_chatbot_frontend.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68bc55c2e5d8832b87aa19432c7bd558