### PR TITLE
Allow direct text responses in chatbot frontend

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -145,7 +145,7 @@ def fetch_first_gdelt_article(
 SYSTEM_PROMPT = (
     "You are a command planner for a terminal application.\n"
     "Output must be a single line: either\n"
-    "CMD: <command> to run, or one clarifying question.\n"
+    "CMD: <command> to run, a concise natural-language answer when no command is needed, or one clarifying question.\n"
     "Do not include code fences, explanations, or extra lines.\n"
     "Available tools:\n"
     '  • curl "<url>" (defaults: -sSL)\n'
@@ -452,23 +452,8 @@ def main() -> None:
             history.append({"role": "assistant", "content": question})
             continue
 
-        # Retry once with a reminder about the expected format
-        history.append(
-            {
-                "role": "user",
-                "content": "Output invalid. Remember the CMD contract.",
-            }
-        )
-        reply = provider.chat(history)
-        command, question = extract_cmd(reply)
-        if command:
-            pending_cmd = command
-        elif question:
-            print(question)
-            history.append({"role": "assistant", "content": question})
-        else:
-            print(reply)
-            history.append({"role": "assistant", "content": reply})
+        print(reply)
+        history.append({"role": "assistant", "content": reply})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- permit natural language answers when no command is needed
- simplify REPL loop to accept direct replies without retries
- add test showing direct follow-up answers without `CMD:` prefix

## Testing
- `PYENV_VERSION=3.11.12 pytest tests/test_chatbot_frontend.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc61a675e4832ba2ad37967b9d1e99