### PR TITLE
feat: add robust news extraction and gdelt fetching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+trafilatura
+readability-lxml
+lxml
+cssselect

--- a/src/sentimental_cap_predictor/news/extract.py
+++ b/src/sentimental_cap_predictor/news/extract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import requests
+
+try:
+    from readability import Document  # optional fallback
+except Exception:
+    Document = None
+
+import trafilatura
+from trafilatura.settings import use_config
+
+UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/118.0.0.0 Safari/537.36"
+)
+
+CONFIG = use_config()
+# make extraction non-finicky about timeouts
+CONFIG.set("DEFAULT", "EXTRACTION_TIMEOUT", "0")
+
+
+def fetch_html(url: str, timeout: int = 20) -> str:
+    resp = requests.get(url, headers={"User-Agent": UA}, timeout=timeout)
+    resp.raise_for_status()
+    return resp.text
+
+
+def extract_main_text(html: str, url: str | None = None) -> str:
+    # 1) Try trafilatura first
+    text = trafilatura.extract(
+        html,
+        url=url,
+        include_comments=False,
+        include_tables=False,
+        config=CONFIG,
+    )
+    if text:
+        return text.strip()
+
+    # 2) Fallback to readability if available
+    if Document is not None:
+        try:
+            doc = Document(html)
+            # readability gives you a cleaned HTML;
+            # strip tags quickly via trafilatura
+            cleaned = trafilatura.extract(
+                doc.summary(html_partial=True),
+                url=url,
+            )
+            if cleaned:
+                return cleaned.strip()
+            return doc.summary().strip()
+        except Exception:
+            pass
+
+    # 3) If all else fails…
+    return ""

--- a/src/sentimental_cap_predictor/news/fetch_gdelt.py
+++ b/src/sentimental_cap_predictor/news/fetch_gdelt.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import argparse
+import json
+import textwrap
+
+import requests
+
+from .extract import extract_main_text, fetch_html
+
+GDELT_DOC_API = "https://api.gdeltproject.org/api/v2/doc/doc"
+UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/118.0.0.0 Safari/537.36"
+)
+
+# Sites that are generally scraper-friendly
+PREFERRED_DOMAINS = (
+    "apnews.com",
+    "reuters.com",
+    "bbc.com",
+    "cnn.com",
+    "nytimes.com",  # still mixed; keep but expect paywalls/403
+    "theguardian.com",
+    "npr.org",
+    "abcnews.go.com",
+    "cbc.ca",
+)
+
+
+def search_gdelt(query: str, max_records: int = 10):
+    params = {
+        "query": query,
+        "mode": "artlist",
+        "format": "json",
+        "maxrecords": max_records,
+        "sort": "datedesc",
+    }
+    r = requests.get(
+        GDELT_DOC_API, params=params, headers={"User-Agent": UA}, timeout=30
+    )
+    r.raise_for_status()
+    data = r.json()
+    return data.get("articles", [])
+
+
+def domain_ok(url: str) -> bool:
+    return any(d in url for d in PREFERRED_DOMAINS)
+
+
+def summarize(text: str, max_chars: int = 800) -> str:
+    text = " ".join(text.split())
+    return textwrap.shorten(text, width=max_chars, placeholder="…")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--query", required=True)
+    ap.add_argument("--max", type=int, default=10)
+    args = ap.parse_args()
+
+    arts = search_gdelt(args.query, args.max)
+    for art in arts:
+        url = art.get("url")
+        if not url:
+            continue
+
+        # prefer friendlier domains if possible
+        if not domain_ok(url):
+            continue
+
+        try:
+            html = fetch_html(url)
+            text = extract_main_text(html, url=url)
+            if not text:
+                # couldn’t extract; skip to next
+                continue
+
+            result = {
+                "title": art.get("title", ""),
+                "url": url,
+                "sourceDomain": art.get("domain", ""),
+                "language": art.get("language", ""),
+                "seendate": art.get("seendate", ""),
+                "text": text,
+                "summary": summarize(text),
+            }
+            print(json.dumps(result, ensure_ascii=False))
+            return
+        except requests.HTTPError:
+            # 403/404/etc. Skip and try next record.
+            continue
+        except Exception:
+            continue
+
+    # If nothing worked, at least return an empty envelope
+    print(json.dumps({"text": "", "summary": ""}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add news extractor preferring trafilatura with readability fallback
- harden GDELT fetcher to skip blocked domains and provide summaries
- document new scraping deps

## Testing
- `python -m pre_commit run --files src/sentimental_cap_predictor/news/extract.py src/sentimental_cap_predictor/news/fetch_gdelt.py requirements.txt`
- `PYTHONPATH=src pytest tests/test_news_cli.py::test_fetch_gdelt_cli -q`
- `PYTHONPATH=src pytest tests/test_article_reader.py::test_extract_main_fallback_to_raw_text -q`
- `pytest tests/test_article_reader.py tests/test_gdelt_client.py tests/test_news.py tests/test_news_cli.py -q` *(fails: ModuleNotFoundError: No module named 'loguru')*
- `PYTHONPATH=src pytest tests/test_article_reader.py tests/test_gdelt_client.py tests/test_news.py tests/test_news_cli.py -q` *(fails: ModuleNotFoundError: No module named 'loguru')*
- `PYTHONPATH=src pytest tests/test_article_reader.py tests/test_gdelt_client.py tests/test_news.py tests/test_news_cli.py -q` *(fails: ModuleNotFoundError: No module named 'loguru')*
- `PYTHONPATH=src python -m sentimental_cap_predictor.news.fetch_gdelt --query "Duke Energy rate hike North Carolina" --max 10` *(fails: No module named 'yfinance')*
- `python src/sentimental_cap_predictor/news/fetch_gdelt.py --query "Duke Energy rate hike North Carolina" --max 10` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5f1f231c832b801e9d03cd2fe352