### PR TITLE
Append web scraping dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ trafilatura
 readability-lxml
 lxml
 cssselect
+
+trafilatura
+readability-lxml
+lxml
+cssselect


### PR DESCRIPTION
## Summary
- append trafilatura, readability-lxml, lxml, and cssselect to requirements.txt

## Testing
- `PYTHONPATH=src pytest` (fails: ModuleNotFoundError: No module named 'typer', 29 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68c03f3f5b04832b990ad02e5a49ba46