### PR TITLE
Add session state dataclass

### DIFF
--- a/src/sentimental_cap_predictor/memory/__init__.py
+++ b/src/sentimental_cap_predictor/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Session state management for the sentimental CAP predictor."""
+
+from .session_state import SessionState, STATE
+
+__all__ = ["SessionState", "STATE"]

--- a/src/sentimental_cap_predictor/memory/session_state.py
+++ b/src/sentimental_cap_predictor/memory/session_state.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SessionState:
+    """Mutable state for maintaining context during chatbot sessions."""
+
+    last_article: dict | None = None
+    recent_chunks: list[str] = field(default_factory=list)
+    last_query: str | None = None
+
+    def set_article(self, article: dict) -> None:
+        """Set the most recently referenced article."""
+        self.last_article = article
+
+    def clear_article(self) -> None:
+        """Clear stored article and related context."""
+        self.last_article = None
+        self.recent_chunks.clear()
+        self.last_query = None
+
+
+STATE = SessionState()


### PR DESCRIPTION
## Summary
- add `SessionState` dataclass to manage article, recent chunks, and last query
- expose a module-level `STATE` for shared session state

## Testing
- `PYENV_VERSION=3.11.12 ruff check src/sentimental_cap_predictor/memory/session_state.py`
- `PYENV_VERSION=3.11.12 pytest tests/test_article_reader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c040b6ad54832b9a6c73cdaaebfb94