### PR TITLE
Add news session handlers for article retrieval and memory search

### DIFF
--- a/src/sentimental_cap_predictor/news/session.py
+++ b/src/sentimental_cap_predictor/news/session.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Session-level helpers for working with fetched news articles."""
+
+from sentimental_cap_predictor.memory import vector_store
+from sentimental_cap_predictor.memory.session_state import STATE
+
+
+def handle_fetch(topic: str) -> str:
+    """Fetch the latest article about *topic* and store it in session state.
+
+    The function queries the GDELT API via :mod:`fetch_gdelt`, extracts the
+    article text, stores text chunks in the vector store and records the
+    article in :data:`STATE`. A short message describing the loaded article
+    is returned. If no suitable article is found an explanatory message is
+    returned instead.
+    """
+
+    from . import fetch_gdelt
+
+    articles = fetch_gdelt.search_gdelt(topic, max_records=15)
+    for art in articles:
+        url = art.get("url")
+        if not url:
+            continue
+        if fetch_gdelt.domain_blocked(url) or not fetch_gdelt.domain_ok(url):
+            continue
+        try:
+            html = fetch_gdelt.fetch_html(url)
+            text = fetch_gdelt.extract_main_text(html, url=url)
+        except Exception:  # pragma: no cover - network failures
+            continue
+        if not text:
+            continue
+        result = {
+            "title": art.get("title", ""),
+            "url": url,
+            "domain": art.get("domain", ""),
+            "language": art.get("language", ""),
+            "seendate": art.get("seendate", ""),
+            "text": text,
+            "summary": fetch_gdelt.summarize(text),
+        }
+        # Persist to vector store and update session state
+        fetch_gdelt._store_chunks(result)
+        STATE.set_article(result)
+        STATE.recent_chunks = fetch_gdelt._chunk_text(text)
+        STATE.last_query = topic
+        return f"Loaded: {result['title']} — {url}"
+
+    STATE.clear_article()
+    return f"No articles found for '{topic}'."
+
+
+def handle_read() -> str:
+    """Return up to 2000 characters from the last fetched article."""
+
+    article = STATE.last_article
+    if not article or not article.get("text"):
+        return "No article loaded. Fetch one with handle_fetch()."
+    return article["text"][:2000]
+
+
+def handle_summarize() -> str:
+    """Return or generate a summary of the last fetched article."""
+
+    article = STATE.last_article
+    if not article:
+        return "No article loaded. Fetch one with handle_fetch()."
+    summary = article.get("summary")
+    if summary:
+        return summary
+    text = article.get("text")
+    if not text:
+        return "No article text to summarize."
+    from .fetch_gdelt import summarize
+
+    summary = summarize(text)
+    article["summary"] = summary
+    return summary
+
+
+def handle_memory_search(query: str) -> str:
+    """Search previously stored article chunks for ``query``."""
+
+    results = vector_store.query(query)
+    if not results:
+        return "No matches found."
+    lines = []
+    for match in results:
+        meta = match.get("metadata", {})
+        title = meta.get("title", "")
+        url = meta.get("url", "")
+        lines.append(f"{title} — {url}".strip())
+    return "\n".join(lines)
+
+
+__all__ = [
+    "handle_fetch",
+    "handle_read",
+    "handle_summarize",
+    "handle_memory_search",
+]

--- a/tests/test_news_session.py
+++ b/tests/test_news_session.py
@@ -1,0 +1,163 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+# Set up lightweight package structure to avoid heavy imports
+root = Path(__file__).resolve().parents[1]
+pkg = SimpleNamespace(__path__=[])
+sys.modules.setdefault("sentimental_cap_predictor", pkg)
+
+memory_pkg = SimpleNamespace(__path__=[])
+sys.modules.setdefault("sentimental_cap_predictor.memory", memory_pkg)
+pkg.memory = memory_pkg
+
+news_pkg = SimpleNamespace(__path__=[])
+sys.modules.setdefault("sentimental_cap_predictor.news", news_pkg)
+pkg.news = news_pkg
+
+# Load actual session_state module (it's lightweight)
+ss_spec = importlib.util.spec_from_file_location(
+    "sentimental_cap_predictor.memory.session_state",
+    root / "src" / "sentimental_cap_predictor" / "memory" / "session_state.py",
+)
+session_state_mod = importlib.util.module_from_spec(ss_spec)
+name = "sentimental_cap_predictor.memory.session_state"
+sys.modules[name] = session_state_mod
+ss_spec.loader.exec_module(session_state_mod)
+memory_pkg.session_state = session_state_mod
+
+# Provide stub vector_store module
+vector_store_mod = SimpleNamespace(
+    query=lambda q: [],
+    upsert=lambda *a, **k: None,
+)
+sys.modules["sentimental_cap_predictor.memory.vector_store"] = vector_store_mod
+memory_pkg.vector_store = vector_store_mod
+
+# Stub fetch_gdelt module for the session helpers
+fetch_gdelt_mod = SimpleNamespace(
+    search_gdelt=lambda *a, **k: [],
+    fetch_html=lambda url: "",
+    extract_main_text=lambda html, url=None: "",
+    summarize=lambda text: "",
+    domain_ok=lambda url: True,
+    domain_blocked=lambda url: False,
+    _store_chunks=lambda result: None,
+    _chunk_text=lambda text: [text],
+)
+sys.modules["sentimental_cap_predictor.news.fetch_gdelt"] = fetch_gdelt_mod
+news_pkg.fetch_gdelt = fetch_gdelt_mod
+
+# Now load the session module under test with package name for relative imports
+spec = importlib.util.spec_from_file_location(
+    "sentimental_cap_predictor.news.session",
+    root / "src" / "sentimental_cap_predictor" / "news" / "session.py",
+)
+session = importlib.util.module_from_spec(spec)
+sys.modules["sentimental_cap_predictor.news.session"] = session
+spec.loader.exec_module(session)
+
+
+def test_handle_fetch_sets_state_and_upserts(monkeypatch):
+    calls = []
+
+    def fake_search_gdelt(query, max_records=15):  # noqa: ANN001
+        return [
+            {
+                "title": f"Title {query}",
+                "url": f"http://{query}.com",
+                "domain": "example.com",
+                "language": "en",
+                "seendate": "today",
+            }
+        ]
+
+    def fake_fetch_html(url):  # noqa: ANN001
+        return "<html></html>"
+
+    def fake_extract(html, url=None):  # noqa: ANN001
+        return "Body text"
+
+    def fake_summarize(text):  # noqa: ANN001
+        return "Summary"
+
+    def fake_upsert(doc_id, text, metadata):  # noqa: ANN001
+        calls.append((doc_id, text, metadata))
+
+    monkeypatch.setattr(
+        session,
+        "vector_store",
+        SimpleNamespace(query=lambda q: [], upsert=fake_upsert),
+    )
+    monkeypatch.setattr(session, "STATE", session.STATE.__class__())
+
+    fg_mod = sys.modules["sentimental_cap_predictor.news.fetch_gdelt"]
+    monkeypatch.setattr(fg_mod, "search_gdelt", fake_search_gdelt)
+    monkeypatch.setattr(fg_mod, "fetch_html", fake_fetch_html)
+    monkeypatch.setattr(fg_mod, "extract_main_text", fake_extract)
+    monkeypatch.setattr(fg_mod, "summarize", fake_summarize)
+    monkeypatch.setattr(fg_mod, "domain_ok", lambda url: True)
+    monkeypatch.setattr(fg_mod, "domain_blocked", lambda url: False)
+    monkeypatch.setattr(
+        fg_mod,
+        "_store_chunks",
+        lambda result: fake_upsert("id", result["text"], {}),
+    )
+    monkeypatch.setattr(fg_mod, "_chunk_text", lambda text: [text])
+
+    msg = session.handle_fetch("topic1")
+    assert msg == "Loaded: Title topic1 — http://topic1.com"
+    assert session.STATE.last_article["title"] == "Title topic1"
+    assert calls  # upsert called
+
+    # Fetch another topic to ensure state replacement
+    msg2 = session.handle_fetch("topic2")
+    assert session.STATE.last_article["title"] == "Title topic2"
+    assert msg2 == "Loaded: Title topic2 — http://topic2.com"
+
+
+def test_handle_read_and_summarize(monkeypatch):
+    monkeypatch.setattr(session, "STATE", session.STATE.__class__())
+
+    # No article loaded
+    assert "No article" in session.handle_read()
+    assert "No article" in session.handle_summarize()
+
+    # Load article
+    session.STATE.set_article({"text": "x" * 2500})
+    # Read should truncate
+    assert len(session.handle_read()) == 2000
+
+    # Summarize with existing summary
+    session.STATE.last_article["summary"] = "sum"
+    assert session.handle_summarize() == "sum"
+
+    # Remove summary, expect generation
+    session.STATE.last_article.pop("summary")
+    fg_mod = sys.modules["sentimental_cap_predictor.news.fetch_gdelt"]
+    monkeypatch.setattr(fg_mod, "summarize", lambda text: "generated")
+    assert session.handle_summarize() == "generated"
+    assert session.STATE.last_article["summary"] == "generated"
+
+
+def test_handle_memory_search(monkeypatch):
+    results = [
+        {"metadata": {"title": "A", "url": "http://a"}},
+        {"metadata": {"title": "B", "url": "http://b"}},
+    ]
+
+    monkeypatch.setattr(
+        session,
+        "vector_store",
+        SimpleNamespace(query=lambda q: results),
+    )
+    text = session.handle_memory_search("q")
+    assert "A — http://a" in text
+    assert "B — http://b" in text
+    monkeypatch.setattr(
+        session,
+        "vector_store",
+        SimpleNamespace(query=lambda q: []),
+    )
+    assert session.handle_memory_search("q") == "No matches found."


### PR DESCRIPTION
## Summary
- implement session handlers for fetching, reading, summarizing, and memory search
- add accompanying tests for session handlers

## Testing
- `python -m pre_commit run --files src/sentimental_cap_predictor/news/session.py tests/test_news_session.py`
- `python -m pytest tests/test_news_session.py`


------
https://chatgpt.com/codex/tasks/task_e_68c047ffc2f0832ba88657f912b3199e