### PR TITLE
Improve logging resilience for news search

### DIFF
--- a/src/sentimental_cap_predictor/memory/vector_store.py
+++ b/src/sentimental_cap_predictor/memory/vector_store.py
@@ -6,7 +6,9 @@ import os
 import tempfile
 from typing import Any, Dict, List
 
-from loguru import logger
+import logging
+
+logger = logging.getLogger(__name__)
 
 try:  # pragma: no cover - optional dependency
     from sentence_transformers import SentenceTransformer
@@ -133,4 +135,10 @@ def query(text: str, k: int = 5) -> List[Dict[str, Any]]:
     ]
 
 
-__all__ = ["ensure_index", "upsert", "query"]
+def available() -> bool:
+    """Return ``True`` if the vector DB and embedding model are usable."""
+
+    return ensure_index() is not None and not _MODEL_FAILED
+
+
+__all__ = ["ensure_index", "upsert", "query", "available"]

--- a/tests/test_news_session.py
+++ b/tests/test_news_session.py
@@ -150,7 +150,7 @@ def test_handle_memory_search(monkeypatch):
     monkeypatch.setattr(
         session,
         "vector_store",
-        SimpleNamespace(query=lambda q: results),
+        SimpleNamespace(query=lambda q: results, available=lambda: True),
     )
     text = session.handle_memory_search("q")
     assert "A — http://a" in text
@@ -158,6 +158,17 @@ def test_handle_memory_search(monkeypatch):
     monkeypatch.setattr(
         session,
         "vector_store",
-        SimpleNamespace(query=lambda q: []),
+        SimpleNamespace(query=lambda q: [], available=lambda: True),
     )
     assert session.handle_memory_search("q") == "No matches found."
+
+
+def test_handle_memory_search_fallback(monkeypatch):
+    monkeypatch.setattr(session, "STATE", session.STATE.__class__())
+    session.STATE.recent_chunks = ["alpha beta", "gamma delta"]
+    monkeypatch.setattr(
+        session,
+        "vector_store",
+        SimpleNamespace(query=lambda q: [], available=lambda: False),
+    )
+    assert "alpha beta" in session.handle_memory_search("alpha")


### PR DESCRIPTION
## Summary
- use Python's logging module for vector store and news session
- warn and skip on network failures in GDelt fetch and session handling
- fall back to session memory when vector DB or embeddings unavailable

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/memory/vector_store.py src/sentimental_cap_predictor/news/session.py src/sentimental_cap_predictor/news/fetch_gdelt.py tests/test_news_session.py` *(fail: command not found)*
- `python3 -m pytest tests/test_news_session.py`
- `python3 -m pytest tests/test_fetch_gdelt_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0567ad0c0832bb6894b1375cf030d