### PR TITLE
Add lightweight smoke test and optional imports

### DIFF
--- a/scripts/smoke_fetch.bat
+++ b/scripts/smoke_fetch.bat
@@ -1,0 +1,12 @@
+@echo off
+set PYTHONPATH=%~dp0\..\src
+
+python --version
+
+python - <<"PY"
+import sentimental_cap_predictor as scp
+print("package:", scp.__name__)
+PY
+
+python -m sentimental_cap_predictor.smoke_cli --help
+python -m sentimental_cap_predictor.smoke_cli "CMD: echo hello"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Lightweight smoke test: ensure Python runs, package imports, config loads,
+# CLI help works and a simple module executes without heavy dependencies.
+set -euo pipefail
+
+export PYTHONPATH="$(dirname "$0")/../src"
+
+python3 --version
+
+python3 - <<'PY'
+import sentimental_cap_predictor as scp
+print("package:", scp.__name__)
+PY
+
+python3 -m sentimental_cap_predictor.smoke_cli --help
+python3 -m sentimental_cap_predictor.smoke_cli "CMD: echo hello"

--- a/src/sentimental_cap_predictor/__init__.py
+++ b/src/sentimental_cap_predictor/__init__.py
@@ -1,3 +1,28 @@
-from . import config, llm_core, trading  # noqa: F401
+"""Top-level package for sentimental_cap_predictor.
+
+This module avoids importing heavy optional dependencies at import time by
+lazily loading subpackages when they are first accessed.  It keeps the package
+importable in lightweight environments used for smoke tests.
+"""
+from importlib import import_module
+from types import ModuleType
+from typing import TYPE_CHECKING
 
 __all__ = ["config", "llm_core", "trading"]
+
+
+def __getattr__(name: str) -> ModuleType:
+    """Dynamically import one of the known subpackages.
+
+    The heavy submodules (for example ``llm_core``) are imported only when they
+    are actually accessed, which means simply importing
+    :mod:`sentimental_cap_predictor` will not pull in large third‑party
+    dependencies such as PyTorch.
+    """
+    if name in __all__:
+        return import_module(f".{name}", __name__)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from . import config, llm_core, trading  # noqa: F401

--- a/src/sentimental_cap_predictor/smoke_cli.py
+++ b/src/sentimental_cap_predictor/smoke_cli.py
@@ -1,0 +1,33 @@
+"""Minimal CLI used for lightweight smoke testing.
+
+The CLI intentionally avoids heavy dependencies and network access.  It simply
+logs the project root using :mod:`sentimental_cap_predictor.config` and exercises
+``extract_cmd`` from :mod:`sentimental_cap_predictor.cmd_utils`.
+"""
+from __future__ import annotations
+
+import argparse
+
+from . import config
+from .cmd_utils import extract_cmd
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Lightweight smoke test CLI")
+    parser.add_argument(
+        "text",
+        nargs="?",
+        default="CMD: echo hello",
+        help="Text input to parse for a command or question",
+    )
+    args = parser.parse_args(argv)
+
+    # Demonstrate that configuration loading works
+    config.log_project_root()
+
+    cmd, question = extract_cmd(args.text)
+    print(f"cmd={cmd!r} question={question!r}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- lazily import heavy subpackages so the top-level package can load without torch
- make configuration resilient when `dotenv` or `loguru` are missing
- add a tiny `smoke_cli` and scripts to prove basic wiring without hitting the network

## Testing
- `./scripts/smoke_test.sh`
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68c05c1b7df0832b9be5ed725dd63cc5