### PR TITLE
Improve news session messaging and state reset

### DIFF
--- a/src/sentimental_cap_predictor/memory/session_state.py
+++ b/src/sentimental_cap_predictor/memory/session_state.py
@@ -12,7 +12,8 @@ class SessionState:
     last_query: str | None = None
 
     def set_article(self, article: dict) -> None:
-        """Set the most recently referenced article."""
+        """Replace the most recently referenced article and reset context."""
+        self.clear_article()
         self.last_article = article
 
     def clear_article(self) -> None:

--- a/src/sentimental_cap_predictor/news/session.py
+++ b/src/sentimental_cap_predictor/news/session.py
@@ -62,7 +62,9 @@ def handle_fetch(topic: str) -> str:
         STATE.set_article(result)
         STATE.recent_chunks = fetch_gdelt._chunk_text(text)
         STATE.last_query = topic
-        return f"Loaded: {result['title']} — {url}"
+        return (
+            f"Loaded: {result['title']} — {url}. Say \"read it\" or \"summarize it\"."
+        )
 
     STATE.clear_article()
     return f"No articles found for '{topic}'."

--- a/tests/test_news_session.py
+++ b/tests/test_news_session.py
@@ -107,14 +107,20 @@ def test_handle_fetch_sets_state_and_upserts(monkeypatch):
     monkeypatch.setattr(fg_mod, "_chunk_text", lambda text: [text])
 
     msg = session.handle_fetch("topic1")
-    assert msg == "Loaded: Title topic1 — http://topic1.com"
+    assert (
+        msg
+        == "Loaded: Title topic1 — http://topic1.com. Say \"read it\" or \"summarize it\"."
+    )
     assert session.STATE.last_article["title"] == "Title topic1"
     assert calls  # upsert called
 
     # Fetch another topic to ensure state replacement
     msg2 = session.handle_fetch("topic2")
     assert session.STATE.last_article["title"] == "Title topic2"
-    assert msg2 == "Loaded: Title topic2 — http://topic2.com"
+    assert (
+        msg2
+        == "Loaded: Title topic2 — http://topic2.com. Say \"read it\" or \"summarize it\"."
+    )
 
 
 def test_handle_read_and_summarize(monkeypatch):


### PR DESCRIPTION
## Summary
- Include follow-up prompt when loading articles
- Reset session context when setting a new article
- Update tests for new messaging

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c062b92a08832b821934b760c3ac70