### PR TITLE
Handle empty GDELT articles and resilient vector store init

### DIFF
--- a/src/sentimental_cap_predictor/news/session.py
+++ b/src/sentimental_cap_predictor/news/session.py
@@ -39,10 +39,17 @@ def handle_fetch(topic: str) -> str:
             continue
         try:
             html = fetch_gdelt.fetch_html(url)
-            text = fetch_gdelt.extract_main_text(html, url=url)
         except requests.RequestException as exc:  # pragma: no cover - network failure
             logger.warning("Network error fetching %s: %s", url, exc)
             continue
+        except Exception as exc:  # pragma: no cover - unexpected failure
+            logger.warning("Error fetching %s: %s", url, exc)
+            continue
+        if fetch_gdelt._is_empty_page(html):
+            logger.info("Skipping %s: empty page", url)
+            continue
+        try:
+            text = fetch_gdelt.extract_main_text(html, url=url)
         except Exception as exc:  # pragma: no cover - extraction failure
             logger.warning("Error processing %s: %s", url, exc)
             continue
@@ -67,6 +74,8 @@ def handle_fetch(topic: str) -> str:
         )
 
     STATE.clear_article()
+    if articles:
+        return "Couldn't fetch a readable article; try another topic."
     return f"No articles found for '{topic}'."
 
 


### PR DESCRIPTION
## Summary
- skip empty/JS-only pages when scanning GDELT results
- fall back with a readable error message if no usable article was found
- guard vector-store initialization so invalid credentials or blocked network don't crash the app

## Testing
- `~/.pyenv/versions/3.11.12/bin/python -m pytest tests/test_news_session.py -q`
- `~/.pyenv/versions/3.11.12/bin/python -m pytest tests/test_fetch_gdelt_store.py -q`
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c063e1a144832b83f585e4997c1c25