### PR TITLE
Skip disallowed domains in GDELT search

### DIFF
--- a/src/sentimental_cap_predictor/news/fetch_gdelt.py
+++ b/src/sentimental_cap_predictor/news/fetch_gdelt.py
@@ -76,6 +76,9 @@ def search_gdelt(query: str, max_records: int = 15):
         url = art.get("url")
         if not url:
             continue
+        if domain_blocked(url):
+            logger.info("Skipping %s: blocked domain", urlparse(url).netloc)
+            continue
         try:  # pragma: no cover - network failure
             html = fetch_html(url)
         except Exception:


### PR DESCRIPTION
## Summary
- Avoid fetching or returning articles from disallowed domains such as wsj.com, ft.com, and bloomberg.com
- Log when a disallowed domain is skipped during GDELT search
- Add tests covering domain filtering in both API and HTML fetch helpers

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_gdelt_client.py::test_search_gdelt_skips_disallowed_domains -q`
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_fetch_gdelt_store.py::test_search_gdelt_skips_blocked_domains -q`
- `PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: No module named 'pandas', 'dotenv', 'requests', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c065a74ba4832b9b83a4df56944961