### PR TITLE
Validate provider configs and guard constructor args

### DIFF
--- a/bin/provider_sig_smoke.py
+++ b/bin/provider_sig_smoke.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+"""Print provider constructor signatures and validate config bindings."""
+from inspect import signature
+
+from sentimental_cap_predictor.llm_core.llm_providers.qwen_local import QwenLocalProvider
+from sentimental_cap_predictor.llm_core.provider_config import QwenLocalConfig
+
+
+def main() -> None:
+    cfg = QwenLocalConfig()
+    sig = signature(QwenLocalProvider.__init__)
+    sig.bind_partial(None, **cfg.model_dump())
+    print("QwenLocalProvider", sig)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/provider_args.md
+++ b/docs/provider_args.md
@@ -1,0 +1,5 @@
+# Provider Args
+
+## QwenLocalProvider
+- `temperature` (float): Sampling temperature for text generation.
+- `max_new_tokens` (int, default: 512): Maximum tokens generated per reply.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
+requests
 trafilatura
 readability-lxml
 lxml
 cssselect
-
-trafilatura
-readability-lxml
-lxml
-cssselect
+pydantic
+colorama

--- a/scripts/smoke_fetch.bat
+++ b/scripts/smoke_fetch.bat
@@ -1,12 +1,13 @@
 @echo off
 set PYTHONPATH=%~dp0\..\src
 
-python --version
-
-python - <<"PY"
-import sentimental_cap_predictor as scp
-print("package:", scp.__name__)
+python - <<PY %*
+from sentimental_cap_predictor.news.fetch_gdelt import search_gdelt
+import json, sys
+query = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "markets"
+result = search_gdelt(query)
+if result:
+    print(result.get("summary", ""))
+else:
+    print("No article found")
 PY
-
-python -m sentimental_cap_predictor.smoke_cli --help
-python -m sentimental_cap_predictor.smoke_cli "CMD: echo hello"

--- a/src/sentimental_cap_predictor/llm_core/__init__.py
+++ b/src/sentimental_cap_predictor/llm_core/__init__.py
@@ -1,6 +1,15 @@
 """Core LLM components: chatbot, NLU, memory and connectors."""
 
-from . import chatbot, chatbot_frontend, chatbot_nlu, connectors, memory_indexer, llm_providers, config_llm  # noqa: F401
+from . import (
+    chatbot,
+    chatbot_frontend,
+    chatbot_nlu,
+    connectors,
+    memory_indexer,
+    llm_providers,
+    config_llm,
+    provider_config,
+)  # noqa: F401
 
 __all__ = [
     "chatbot",
@@ -10,4 +19,5 @@ __all__ = [
     "memory_indexer",
     "llm_providers",
     "config_llm",
+    "provider_config",
 ]

--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -471,16 +471,23 @@ def main() -> None:
     """Run a REPL-style chat session with the local Qwen model."""
     setup()
     from sentimental_cap_predictor.cmd_utils import extract_cmd
-    from sentimental_cap_predictor.llm_core.config_llm import get_llm_config
+    from sentimental_cap_predictor.llm_core.provider_config import (
+        QwenLocalConfig,
+    )
     from sentimental_cap_predictor.llm_core.llm_providers.qwen_local import (
         QwenLocalProvider,
     )
 
-    config = get_llm_config()
-    provider = QwenLocalProvider(
-        temperature=config.temperature,
-        max_new_tokens=config.max_new_tokens,
-    )
+    cfg = QwenLocalConfig.from_env()
+    try:
+        provider = QwenLocalProvider(**cfg.model_dump())
+    except TypeError as e:  # pragma: no cover - defensive
+        import inspect
+        import sentimental_cap_predictor.llm_core.llm_providers.qwen_local as ql
+
+        print("Provider init failed. Here is the expected signature:")
+        print(inspect.signature(ql.QwenLocalProvider.__init__))
+        raise
     history: list[dict[str, str]] = [
         {"role": "system", "content": SYSTEM_PROMPT},
     ]

--- a/src/sentimental_cap_predictor/llm_core/chatbot_nlu/qwen_intent.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_nlu/qwen_intent.py
@@ -5,7 +5,7 @@ import json
 import re as _re
 from typing import Any, Dict, TYPE_CHECKING
 
-from ..config_llm import get_llm_config
+from ..provider_config import QwenLocalConfig
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from ..llm_providers.qwen_local import QwenLocalProvider
@@ -64,13 +64,11 @@ def call_qwen(utterance: str) -> str:
             QwenLocalProvider,
         )
 
-        cfg = get_llm_config()
+        cfg = QwenLocalConfig.from_env()
         # Use deterministic settings for intent classification
         _LOCAL_PROVIDER = QwenLocalProvider(
-            model_path=cfg.model_path,
             temperature=0.0,
             max_new_tokens=cfg.max_new_tokens,
-            offload_folder=getattr(cfg, "offload_folder", None),
         )
 
     messages = [

--- a/src/sentimental_cap_predictor/llm_core/provider_config.py
+++ b/src/sentimental_cap_predictor/llm_core/provider_config.py
@@ -1,0 +1,20 @@
+"""Typed configuration models for LLM providers."""
+from __future__ import annotations
+
+import os
+from pydantic import BaseModel, Field
+
+
+class QwenLocalConfig(BaseModel):
+    """Configuration options for :class:`QwenLocalProvider`."""
+
+    temperature: float = Field(default=0.7)
+    max_new_tokens: int = Field(default=512)
+
+    @classmethod
+    def from_env(cls) -> "QwenLocalConfig":
+        """Load configuration from environment variables."""
+        return cls(
+            temperature=float(os.getenv("LLM_TEMPERATURE", 0.7)),
+            max_new_tokens=int(os.getenv("LLM_MAX_NEW_TOKENS", 512)),
+        )

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -358,14 +358,27 @@ def test_direct_text_reply(monkeypatch, capsys):
         "sentimental_cap_predictor.llm_core.llm_providers.qwen_local",
         dummy_module,
     )
+    cfg_module = SimpleNamespace(
+        QwenLocalConfig=SimpleNamespace(
+            from_env=lambda: SimpleNamespace(
+                temperature=0.0,
+                max_new_tokens=512,
+                model_dump=lambda: {"temperature": 0.0, "max_new_tokens": 512},
+            )
+        )
+    )
+    llm_core_pkg = SimpleNamespace(provider_config=cfg_module)
+    root_pkg = SimpleNamespace(llm_core=llm_core_pkg)
+    monkeypatch.setitem(sys.modules, "sentimental_cap_predictor", root_pkg)
     monkeypatch.setitem(
         sys.modules,
-        "sentimental_cap_predictor.llm_core.config_llm",
-        SimpleNamespace(
-            get_llm_config=lambda: SimpleNamespace(
-                model_path="", temperature=0.0, max_new_tokens=512
-            )
-        ),
+        "sentimental_cap_predictor.llm_core",
+        llm_core_pkg,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sentimental_cap_predictor.llm_core.provider_config",
+        cfg_module,
     )
     import importlib.util
     from pathlib import Path

--- a/tests/test_provider_signatures.py
+++ b/tests/test_provider_signatures.py
@@ -1,0 +1,66 @@
+import contextlib
+import types
+
+import pytest
+
+ql = pytest.importorskip(
+    "sentimental_cap_predictor.llm_core.llm_providers.qwen_local",
+    reason="qwen provider not available",
+)
+from sentimental_cap_predictor.llm_core.provider_config import QwenLocalConfig
+
+
+def _patch_qwen(monkeypatch):
+    class DummyTokenizer:
+        pass
+
+    class DummyConfig:
+        pass
+
+    class DummyModel:
+        def tie_weights(self):
+            pass
+
+        def eval(self):
+            return self
+
+    monkeypatch.setattr(
+        ql, "AutoTokenizer", types.SimpleNamespace(from_pretrained=lambda *a, **k: DummyTokenizer())
+    )
+    monkeypatch.setattr(
+        ql, "AutoConfig", types.SimpleNamespace(from_pretrained=lambda *a, **k: DummyConfig())
+    )
+    monkeypatch.setattr(
+        ql,
+        "AutoModelForCausalLM",
+        types.SimpleNamespace(from_config=lambda *a, **k: DummyModel()),
+    )
+    monkeypatch.setattr(ql, "init_empty_weights", lambda: contextlib.nullcontext())
+    monkeypatch.setattr(
+        ql,
+        "load_checkpoint_and_dispatch",
+        lambda model, checkpoint, device_map=None, offload_folder=None, dtype=None: model,
+    )
+    monkeypatch.setattr(
+        ql,
+        "_auto_runtime_prefs",
+        lambda: {
+            "model_path": "dummy",
+            "device_map": "cpu",
+            "dtype": None,
+            "offload_folder": "/tmp",
+        },
+    )
+
+
+@pytest.mark.skipif(not hasattr(ql, "QwenLocalProvider"), reason="provider missing")
+def test_qwen_local_provider_init(monkeypatch):
+    _patch_qwen(monkeypatch)
+    cfg = QwenLocalConfig()
+    provider = ql.QwenLocalProvider(**cfg.model_dump())
+    assert provider.max_new_tokens == cfg.max_new_tokens
+
+
+def test_qwen_local_provider_unknown_kwargs():
+    with pytest.raises(TypeError):
+        ql.QwenLocalProvider(temperature=0.1, max_new_tokens=1, foo=1)


### PR DESCRIPTION
## Summary
- introduce pydantic-based QwenLocalConfig and enforce strict provider kwargs
- update chatbot and intent classifier to build providers from validated config and show signature on mismatch
- add provider signature tests, dynamic GDELT module resolution, and smoke script

## Testing
- `PYENV_VERSION=3.11.12 pip install -r requirements.txt`
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_provider_signatures.py tests/test_chatbot_frontend.py tests/test_extract_and_store.py tests/test_fetch_gdelt_store.py tests/test_news_session.py -q`
- `PYENV_VERSION=3.11.12 PYTHONPATH=src python bin/provider_sig_smoke.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c037a9a670832ba6401e82da4d3550