### PR TITLE
Add analogy reasoning helpers

### DIFF
--- a/src/sentimental_cap_predictor/reasoning/__init__.py
+++ b/src/sentimental_cap_predictor/reasoning/__init__.py
@@ -1,5 +1,6 @@
 """Reasoning utilities and schemas."""
 
+from .analogy import best_metaphor, map_roles
 from .schemas import BalanceSchema, ContainerSchema, ForceSchema, PathSchema
 
 __all__ = [
@@ -7,4 +8,6 @@ __all__ = [
     "ContainerSchema",
     "ForceSchema",
     "PathSchema",
+    "best_metaphor",
+    "map_roles",
 ]

--- a/src/sentimental_cap_predictor/reasoning/analogy.py
+++ b/src/sentimental_cap_predictor/reasoning/analogy.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Analogical reasoning helpers."""
+
+from typing import Dict, Tuple
+
+
+def map_roles(
+    source: Dict[str, str],
+    target: Dict[str, str],
+) -> Dict[str, str]:
+    """Align role fillers shared by two conceptual frames.
+
+    Parameters
+    ----------
+    source:
+        Mapping from role names to fillers in the source domain.
+    target:
+        Mapping from role names to fillers in the target domain.
+
+    Returns
+    -------
+    Dict[str, str]
+        Mapping from each source filler to its counterpart in the target for
+        roles that both domains contain. Roles missing in the target are
+        ignored.
+    """
+
+    mapping: Dict[str, str] = {}
+    for role, source_value in source.items():
+        if role in target:
+            mapping[source_value] = target[role]
+    return mapping
+
+
+# Simple knowledge base of metaphors for demonstration purposes.
+_METAPHORS: Dict[str, Tuple[str, str]] = {
+    "brain": (
+        "computer",
+        "Both process information through electrical signals.",
+    ),
+    "stock market": (
+        "rollercoaster",
+        "Its values rise and fall dramatically like cars on a ride.",
+    ),
+    "internet": (
+        "highway",
+        "Information flows quickly between nodes like vehicles on roads.",
+    ),
+}
+
+
+def best_metaphor(target_concept: str) -> Tuple[str, str]:
+    """Return a metaphor label and short rationale for a concept.
+
+    Parameters
+    ----------
+    target_concept:
+        Concept to describe metaphorically.
+
+    Returns
+    -------
+    tuple[str, str]
+        ``(label, rationale)`` describing the metaphor. If no metaphor is
+        available, the label is empty and the rationale explains this.
+    """
+
+    key = target_concept.lower()
+    default = ("", f"No metaphor available for {target_concept}")
+    return _METAPHORS.get(key, default)

--- a/tests/reasoning/test_analogy.py
+++ b/tests/reasoning/test_analogy.py
@@ -1,0 +1,22 @@
+from sentimental_cap_predictor.reasoning.analogy import (
+    best_metaphor,
+    map_roles,
+)
+
+
+def test_map_roles_basic() -> None:
+    source = {"hero": "Frodo", "villain": "Sauron"}
+    target = {"hero": "Luke", "villain": "Vader", "mentor": "Yoda"}
+    assert map_roles(source, target) == {"Frodo": "Luke", "Sauron": "Vader"}
+
+
+def test_best_metaphor_known() -> None:
+    label, rationale = best_metaphor("brain")
+    assert label == "computer"
+    assert "information" in rationale
+
+
+def test_best_metaphor_unknown() -> None:
+    label, rationale = best_metaphor("unknown")
+    assert label == ""
+    assert "No metaphor" in rationale


### PR DESCRIPTION
## Summary
- add `analogy` module with `map_roles` and `best_metaphor`
- expose new reasoning helpers from package
- add tests for analogy helpers

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/reasoning/analogy.py src/sentimental_cap_predictor/reasoning/__init__.py tests/reasoning/test_analogy.py`
- `pytest tests/reasoning/test_analogy.py -q`
- `pytest` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c1a9002b38832bb8d6888f3be67062