### PR TITLE
Add simple trend-force simulator

### DIFF
--- a/src/sentimental_cap_predictor/reasoning/simulator.py
+++ b/src/sentimental_cap_predictor/reasoning/simulator.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Very small deterministic simulator for trend and force states."""
+
+from typing import Dict, Tuple
+
+State = Dict[str, str]
+
+
+def step(state: State) -> Tuple[State, str]:
+    """Advance one step in the simulation.
+
+    Parameters
+    ----------
+    state:
+        Mapping with keys ``"trend"`` and ``"force"``. ``"trend`` may be
+        ``"up"`` or ``"down"``; ``"force"`` may be ``"weak"`` or ``"strong"``.
+
+    Returns
+    -------
+    tuple[State, str]
+        ``(next_state, narration)`` describing the updated state and a short
+        explanation of what occurred.
+
+    Raises
+    ------
+    KeyError
+        If required keys are missing.
+    ValueError
+        If values are outside the allowed sets.
+    """
+
+    trend = state["trend"]
+    force = state["force"]
+
+    if trend not in {"up", "down"}:
+        raise ValueError("trend must be 'up' or 'down'")
+    if force not in {"weak", "strong"}:
+        raise ValueError("force must be 'weak' or 'strong'")
+
+    if force == "strong":
+        next_trend = trend
+        next_force = "weak"
+        narration = f"Strong force keeps the trend {next_trend}."
+    else:
+        next_trend = "down" if trend == "up" else "up"
+        next_force = "strong"
+        narration = f"Weak force allows the trend to reverse to {next_trend}."
+
+    next_state: State = {"trend": next_trend, "force": next_force}
+    return next_state, narration

--- a/tests/reasoning/test_simulator.py
+++ b/tests/reasoning/test_simulator.py
@@ -1,0 +1,24 @@
+import pytest
+
+from sentimental_cap_predictor.reasoning.simulator import step
+
+
+def test_step_strong_force_keeps_trend() -> None:
+    state = {"trend": "up", "force": "strong"}
+    next_state, narration = step(state)
+    assert next_state == {"trend": "up", "force": "weak"}
+    assert "Strong force keeps the trend up" in narration
+
+
+def test_step_weak_force_reverses_trend() -> None:
+    state = {"trend": "down", "force": "weak"}
+    next_state, narration = step(state)
+    assert next_state == {"trend": "up", "force": "strong"}
+    assert "reverse" in narration and "up" in narration
+
+
+def test_step_invalid_values() -> None:
+    with pytest.raises(ValueError):
+        step({"trend": "sideways", "force": "strong"})
+    with pytest.raises(ValueError):
+        step({"trend": "up", "force": "medium"})


### PR DESCRIPTION
## Summary
- add deterministic trend/force simulator
- cover simulator with unit tests

## Testing
- `PYENV_VERSION=3.11.12 pre-commit run --files src/sentimental_cap_predictor/reasoning/simulator.py tests/reasoning/test_simulator.py -v`
- `PYENV_VERSION=3.11.12 python -m pytest tests/reasoning/test_simulator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1aaaf0b88832ba23e31a78396876b