### PR TITLE
Add reasoning engine utilities

### DIFF
--- a/src/sentimental_cap_predictor/reasoning/__init__.py
+++ b/src/sentimental_cap_predictor/reasoning/__init__.py
@@ -1,6 +1,7 @@
 """Reasoning utilities and schemas."""
 
 from .analogy import best_metaphor, map_roles
+from .engine import analogy_explain, reason_about, simulate
 from .schemas import BalanceSchema, ContainerSchema, ForceSchema, PathSchema
 
 __all__ = [
@@ -10,4 +11,7 @@ __all__ = [
     "PathSchema",
     "best_metaphor",
     "map_roles",
+    "analogy_explain",
+    "reason_about",
+    "simulate",
 ]

--- a/src/sentimental_cap_predictor/reasoning/engine.py
+++ b/src/sentimental_cap_predictor/reasoning/engine.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+"""High level reasoning engine built atop simple helpers."""
+
+from typing import Any, Dict, List, Optional
+
+from ..memory import vector_store
+from .analogy import best_metaphor
+from .simulator import step as sim_step
+
+
+def reason_about(
+    text: str,
+    memory_hits: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """Return an explanation contrasting retrieved facts and speculation.
+
+    Parameters
+    ----------
+    text:
+        Claim or question to analyze.
+    memory_hits:
+        Optional list of matches from :mod:`vector_store`. If ``None``, the
+        store is queried directly when available.
+
+    Returns
+    -------
+    str
+        Multi-line explanation where factual snippets precede speculative
+        reasoning.
+    """
+
+    hits = memory_hits
+    if hits is None:
+        hits = vector_store.query(text) if vector_store.available() else []
+
+    facts: List[str] = []
+    for hit in hits or []:
+        meta = hit.get("metadata", {}) or {}
+        snippet = meta.get("text")
+        if not snippet:
+            snippet = meta.get("snippet")
+        if not snippet:
+            snippet = meta.get("summary")
+        source = meta.get("source") or hit.get("id", "unknown")
+        if snippet:
+            facts.append(f"- {snippet} (source: {source})")
+
+    if facts:
+        fact_block = "Facts:\n" + "\n".join(facts)
+    else:
+        fact_block = "Facts:\n- No supporting evidence retrieved."
+
+    spec_text = text if text else "No speculation provided."
+    spec_block = f"Speculation:\n{spec_text}"
+    return f"{fact_block}\n\n{spec_block}"
+
+
+def analogy_explain(src: str, tgt: str) -> str:
+    """Provide a short analogy comparing ``src`` and ``tgt`` with caveats."""
+
+    label, rationale = best_metaphor(tgt)
+    if label:
+        para1 = (
+            f"{tgt.capitalize()} can be likened to a {label}. {rationale} "
+            f"This mirrors aspects of {src}."
+        )
+    else:
+        para1 = (
+            f"There is no ready-made metaphor for {tgt}. "
+            f"Still, comparing it to {src} can offer intuition."
+        )
+
+    para2 = (
+        f"However, {tgt} and {src} are not identical, "
+        "so the analogy should be taken as a loose comparison "
+        "rather than a strict equivalence."
+    )
+    return f"{para1}\n\n{para2}"
+
+
+def simulate(scenario: str) -> str:
+    """Parse qualitative ``scenario`` and narrate one step of the simulator."""
+
+    text = scenario.lower()
+    trend = "down" if "down" in text else "up"
+    force = "strong" if "strong" in text else "weak"
+    state: Dict[str, str] = {"trend": trend, "force": force}
+    try:
+        next_state, narration = sim_step(state)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        return f"Simulation failed: {exc}"
+
+    return (
+        f"Starting with trend={trend} and force={force}. "
+        f"{narration} Next state: trend={next_state['trend']}, "
+        f"force={next_state['force']}."
+    )


### PR DESCRIPTION
## Summary
- add reasoning engine with `reason_about`, `analogy_explain`, and `simulate`
- expose engine helpers through reasoning package

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/reasoning/engine.py src/sentimental_cap_predictor/reasoning/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c1ac6f9a2c832bbb76a3c3967dcfb0