### PR TITLE
Add reasoning command routing to chatbot frontend

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -21,6 +21,11 @@ from sentimental_cap_predictor.data.news import (
     FetchArticleSpec,
 )
 from sentimental_cap_predictor.data.news import fetch_article as _fetch_article
+from sentimental_cap_predictor.reasoning.engine import (
+    analogy_explain,
+    reason_about,
+    simulate,
+)
 
 _MEMORY_INDEX: Path | None = None
 _SEEN_URLS: set[str] = set()
@@ -463,6 +468,43 @@ def _route_keywords(message: str) -> Callable[[], str] | None:
             return handle_command(f'memory search "{query}"')
 
         return _search
+
+    m = re.match(r"reason about (.+)", message, re.I)
+    if m:
+        topic = m.group(1).strip()
+
+        def _reason():
+            logger.info("Dispatching reason_about: %s", topic)
+            result = reason_about(topic)
+            logger.info("Finished reason_about: %s", topic)
+            return result
+
+        return _reason
+
+    m = re.match(r"simulate (.+)", message, re.I)
+    if m:
+        scenario = m.group(1).strip()
+
+        def _simulate():
+            logger.info("Dispatching simulate: %s", scenario)
+            result = simulate(scenario)
+            logger.info("Finished simulate: %s", scenario)
+            return result
+
+        return _simulate
+
+    m = re.match(r"explain with analogy (.+?) to (.+)", message, re.I)
+    if m:
+        src = m.group(1).strip()
+        tgt = m.group(2).strip()
+
+        def _analogy():
+            logger.info("Dispatching analogy_explain: %s -> %s", src, tgt)
+            result = analogy_explain(src, tgt)
+            logger.info("Finished analogy_explain: %s -> %s", src, tgt)
+            return result
+
+        return _analogy
 
     return None
 

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 import requests
+import logging
 
 
 @dataclass
@@ -618,3 +619,25 @@ def test_route_keywords_last_loaded():
     handler = cf._route_keywords("what did you load?")
     assert handler is not None
     assert handler() == "T - http://u"
+
+
+def test_route_keywords_reason_simulate_analogy(monkeypatch, caplog):
+    monkeypatch.setattr(cf, "reason_about", lambda topic: f"reasoned {topic}")
+    handler = cf._route_keywords("reason about inflation")
+    assert handler is not None
+    with caplog.at_level(logging.INFO):
+        assert handler() == "reasoned inflation"
+
+    monkeypatch.setattr(cf, "simulate", lambda scenario: f"sim {scenario}")
+    handler = cf._route_keywords("simulate market crash")
+    assert handler is not None
+    with caplog.at_level(logging.INFO):
+        assert handler() == "sim market crash"
+
+    monkeypatch.setattr(
+        cf, "analogy_explain", lambda src, tgt: f"{src}->{tgt}"
+    )
+    handler = cf._route_keywords("explain with analogy stocks to gambling")
+    assert handler is not None
+    with caplog.at_level(logging.INFO):
+        assert handler() == "stocks->gambling"


### PR DESCRIPTION
## Summary
- route `reason about`, `simulate`, and `explain with analogy` phrases to reasoning engine
- log before and after reasoning dispatches for traceability
- add tests for new keyword routing

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_chatbot_frontend.py::test_route_keywords_reason_simulate_analogy -q`
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_68c1ae8f2d94832b8dc5e828bb7652dd