### PR TITLE
Add cognitive linguistics guide and sample chatbot prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Responses that begin with `CMD:` request that your environment execute the
 following shell command. Use an external runner that detects this prefix,
 runs the command, and feeds its output back to the chat session.
 
+Example prompts:
+
+```text
+reason about NVIDIA guidance
+explain with analogy earnings to weather forecast
+simulate market reaction to rate cut (trend up, force strong)
+```
+
 ## Documentation
 
 See the [User Manual](docs/user_manual.md) for environment setup, workflow

--- a/docs/cognitive_linguistics.md
+++ b/docs/cognitive_linguistics.md
@@ -1,0 +1,23 @@
+# Cognitive Linguistics Overview
+
+## Image Schemas
+Image schemas are recurring spatial patterns that structure our understanding of experience. They provide a basic scaffold for reasoning. For example, the **container** schema frames "in" and "out":
+
+> The stock is *in* a downturn.
+
+Here, market performance is conceptualized as being inside or outside a bounded region.
+
+## Analogy
+Analogy maps knowledge from one domain to another to highlight similarities. It supports explanations by linking new ideas to familiar ones. For instance:
+
+> Earnings season is like a school report card—past efforts are graded and future expectations are set.
+
+This analogy connects corporate financial reporting with an everyday evaluation process.
+
+## Simulator
+A simulator mentally enacts scenarios to anticipate outcomes. It allows us to explore consequences without acting in the real world. Example:
+
+> Imagine lowering interest rates: investors rush in, prices climb, and momentum builds.
+
+The mind runs a simulation of a rate cut to predict market behavior.
+


### PR DESCRIPTION
## Summary
- Document image schemas, analogy, and simulator concepts with brief market-related examples
- Showcase example chatbot prompts for reasoning about NVIDIA guidance, analogy between earnings and weather, and simulating a rate-cut reaction

## Testing
- `OFFLINE_TEST=1 pytest -q` *(fails: pyenv version `3.11.9` not installed; `pytest` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b130932c832b8ab02fba63ab1d77