### PR TITLE
Handle missing data in reasoning engine

### DIFF
--- a/tests/reasoning/test_engine.py
+++ b/tests/reasoning/test_engine.py
@@ -1,0 +1,20 @@
+from sentimental_cap_predictor.reasoning import engine
+
+
+def test_reason_about_no_hits(monkeypatch):
+    monkeypatch.setattr(engine.vector_store, "available", lambda: True)
+    monkeypatch.setattr(engine.vector_store, "query", lambda text: [])
+    result = engine.reason_about("any topic")
+    assert "No relevant memories found" in result
+
+
+def test_analogy_explain_disjoint_dicts():
+    src = {"hero": "Alice"}
+    tgt = {"villain": "Bob"}
+    result = engine.analogy_explain(src, tgt)
+    assert "no analogous roles" in result.lower()
+
+
+def test_simulate_unknown_knobs():
+    result = engine.simulate("trend sideways with moderate force")
+    assert "generic outcome" in result.lower()


### PR DESCRIPTION
## Summary
- Handle empty vector store hits gracefully in `reason_about`
- Expand `analogy_explain` to align role dictionaries and report gaps
- Validate knobs in `simulate` and fall back to generic outcome on unknown values
- Add tests covering reasoning engine edge cases

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/reasoning/test_engine.py tests/reasoning/test_analogy.py tests/test_reasoning_basic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1b1d6fd14832b96436f4a7620ed0c