### PR TITLE
Add DeepSeek LLM provider and configuration

### DIFF
--- a/bin/provider_sig_smoke.py
+++ b/bin/provider_sig_smoke.py
@@ -3,14 +3,22 @@
 from inspect import signature
 
 from sentimental_cap_predictor.llm_core.llm_providers.qwen_local import QwenLocalProvider
-from sentimental_cap_predictor.llm_core.provider_config import QwenLocalConfig
+from sentimental_cap_predictor.llm_core.llm_providers.deepseek import DeepSeekProvider
+from sentimental_cap_predictor.llm_core.provider_config import (
+    DeepSeekConfig,
+    QwenLocalConfig,
+)
 
 
 def main() -> None:
-    cfg = QwenLocalConfig()
-    sig = signature(QwenLocalProvider.__init__)
-    sig.bind_partial(None, **cfg.model_dump())
-    print("QwenLocalProvider", sig)
+    providers = [
+        ("QwenLocalProvider", QwenLocalProvider, QwenLocalConfig()),
+        ("DeepSeekProvider", DeepSeekProvider, DeepSeekConfig()),
+    ]
+    for name, cls, cfg in providers:
+        sig = signature(cls.__init__)
+        sig.bind_partial(None, **cfg.model_dump())
+        print(name, sig)
 
 
 if __name__ == "__main__":

--- a/src/sentimental_cap_predictor/llm_core/llm_providers/deepseek.py
+++ b/src/sentimental_cap_predictor/llm_core/llm_providers/deepseek.py
@@ -1,0 +1,101 @@
+"""DeepSeek provider supporting local or API-hosted models."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional
+
+from ..utils import clean_generate_kwargs
+from .base import ChatMessage, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class DeepSeekProvider(LLMProvider):
+    """Implementation of :class:`LLMProvider` for DeepSeek models.
+
+    The provider can operate in two modes:
+
+    * **API mode** when an API key is supplied via ``api_key`` or the
+      ``DEEPSEEK_API_KEY`` environment variable.  Requests are sent using the
+      OpenAI-compatible client.
+    * **Local mode** when ``model_path`` (or ``DEEPSEEK_MODEL_PATH``) points to a
+      local Hugging Face model checkpoint.  The model is loaded with
+      :mod:`transformers` and executed locally.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: Optional[str] = None,
+        model_path: Optional[str] = None,
+        api_key: Optional[str] = None,
+        temperature: float = 0.7,
+        max_new_tokens: int = 512,
+        **kwargs: Any,
+    ) -> None:
+        if kwargs:
+            raise TypeError(f"Unknown args: {sorted(kwargs.keys())}")
+
+        self.temperature = temperature
+        self.max_new_tokens = max_new_tokens
+
+        self.api_key = api_key or os.getenv("DEEPSEEK_API_KEY")
+        self.model_id = model or os.getenv("DEEPSEEK_MODEL", "deepseek-chat")
+        self.model_path = model_path or os.getenv("DEEPSEEK_MODEL_PATH")
+
+        if self.api_key:
+            try:
+                from openai import OpenAI  # type: ignore
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise RuntimeError(
+                    "openai package required for DeepSeek API usage"
+                ) from exc
+            base_url = os.getenv("DEEPSEEK_API_BASE", "https://api.deepseek.com")
+            self.client = OpenAI(api_key=self.api_key, base_url=base_url)
+            logger.info("DeepSeek API client initialized model=%s base=%s", self.model_id, base_url)
+            self._local = False
+        else:
+            from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore
+            import torch
+
+            path = self.model_path or self.model_id
+            self.tokenizer = AutoTokenizer.from_pretrained(path)
+            self.model = AutoModelForCausalLM.from_pretrained(path).eval()
+            self._torch = torch
+            self.model_id = path
+            self._local = True
+            logger.info("Loaded DeepSeek local model %s", path)
+
+    def chat(self, messages: List[ChatMessage], **kwargs: Any) -> str:
+        if self._local:
+            prompt = self.tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            tokenized = self.tokenizer(prompt, return_tensors="pt")
+            inputs = tokenized.to(self.model.device)
+            kwargs.setdefault("max_new_tokens", self.max_new_tokens)
+            kwargs.setdefault(
+                "max_length",
+                inputs["input_ids"].shape[-1] + kwargs["max_new_tokens"],
+            )
+            generate_kwargs = clean_generate_kwargs(
+                temperature=self.temperature,
+                **kwargs,
+            )
+            with self._torch.no_grad():
+                outputs = self.model.generate(**inputs, **generate_kwargs)
+            start = inputs["input_ids"].shape[-1]
+            generated = outputs[0, start:]
+            return self.tokenizer.decode(generated, skip_special_tokens=True)
+
+        completion = self.client.chat.completions.create(
+            model=self.model_id,
+            messages=messages,
+            temperature=self.temperature,
+            max_tokens=kwargs.get("max_new_tokens", self.max_new_tokens),
+        )
+        message = completion.choices[0].message
+        if isinstance(message, dict):  # compatibility with simple mocks
+            return message.get("content", "")
+        return getattr(message, "content", "")

--- a/src/sentimental_cap_predictor/llm_core/provider_config.py
+++ b/src/sentimental_cap_predictor/llm_core/provider_config.py
@@ -2,7 +2,15 @@
 from __future__ import annotations
 
 import os
+from enum import Enum
 from pydantic import BaseModel, Field
+
+
+class LLMProviderEnum(str, Enum):
+    """Enumerate supported LLM provider backends."""
+
+    qwen_local = "qwen_local"
+    deepseek = "deepseek"
 
 
 class QwenLocalConfig(BaseModel):
@@ -17,4 +25,32 @@ class QwenLocalConfig(BaseModel):
         return cls(
             temperature=float(os.getenv("LLM_TEMPERATURE", 0.7)),
             max_new_tokens=int(os.getenv("LLM_MAX_NEW_TOKENS", 512)),
+        )
+
+
+DEFAULT_DEEPSEEK_INSTRUCT_MODEL = "deepseek-chat"
+"""Default model name for DeepSeek instruct/chat usage."""
+
+DEFAULT_DEEPSEEK_CODER_MODEL = "deepseek-coder"
+"""Default model name for DeepSeek code generation."""
+
+
+class DeepSeekConfig(BaseModel):
+    """Configuration options for :class:`DeepSeekProvider`."""
+
+    temperature: float = Field(default=0.7)
+    max_new_tokens: int = Field(default=512)
+    model: str = Field(default=DEFAULT_DEEPSEEK_INSTRUCT_MODEL)
+    model_path: str | None = Field(default=None)
+    api_key: str | None = Field(default=None)
+
+    @classmethod
+    def from_env(cls) -> "DeepSeekConfig":
+        """Load configuration from environment variables."""
+        return cls(
+            temperature=float(os.getenv("LLM_TEMPERATURE", 0.7)),
+            max_new_tokens=int(os.getenv("LLM_MAX_NEW_TOKENS", 512)),
+            model=os.getenv("DEEPSEEK_MODEL", DEFAULT_DEEPSEEK_INSTRUCT_MODEL),
+            model_path=os.getenv("DEEPSEEK_MODEL_PATH"),
+            api_key=os.getenv("DEEPSEEK_API_KEY"),
         )


### PR DESCRIPTION
## Summary
- add DeepSeekProvider supporting local checkpoints or API calls
- expand provider_config with DeepSeek defaults and LLMProviderEnum entry
- include DeepSeek in provider signature checks and tests

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f0af36e8832b9d6eff0384824767