### PR TITLE
Add agent tool registry and loop

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/agent/__init__.py
+++ b/src/sentimental_cap_predictor/llm_core/agent/__init__.py
@@ -1,0 +1,9 @@
+from .loop import AgentLoop
+from .tool_registry import ToolSpec, get_tool, register_tool
+
+__all__ = [
+    "ToolSpec",
+    "register_tool",
+    "get_tool",
+    "AgentLoop",
+]

--- a/src/sentimental_cap_predictor/llm_core/agent/loop.py
+++ b/src/sentimental_cap_predictor/llm_core/agent/loop.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Callable, List
+
+from .tool_registry import get_tool
+
+
+class AgentLoop:
+    """Simple controller implementing a Thought→CMD→Observation loop."""
+
+    def __init__(
+        self,
+        llm: Callable[[str], str],
+        max_steps: int = 5,
+        timeout: float = 30.0,
+    ) -> None:
+        self._llm = llm
+        self._max_steps = max_steps
+        self._timeout = timeout
+
+    def run(self, prompt: str) -> str:
+        """Execute the agent loop starting from ``prompt``.
+
+        Parameters
+        ----------
+        prompt:
+            Initial text sent to the model.
+
+        Returns
+        -------
+        str
+            Final answer when no ``CMD:`` block is present.
+
+        Raises
+        ------
+        TimeoutError
+            If the loop runs longer than ``timeout`` seconds.
+        RuntimeError
+            If ``max_steps`` is reached without producing a final answer.
+        """
+
+        observations: List[str] = []
+        start = time.time()
+        for _ in range(self._max_steps):
+            if time.time() - start > self._timeout:
+                raise TimeoutError("Agent loop timed out")
+
+            model_input = self._build_prompt(prompt, observations)
+            model_output = self._llm(model_input)
+
+            cmd = self._extract_cmd(model_output)
+            if cmd is None:
+                return model_output.strip()
+
+            observation = self._dispatch(cmd)
+            observations.append(observation)
+
+        raise RuntimeError("Agent loop exceeded maximum steps")
+
+    @staticmethod
+    def _build_prompt(prompt: str, observations: List[str]) -> str:
+        if not observations:
+            return prompt
+        obs_text = "\n".join(f"Observation: {o}" for o in observations)
+        return f"{prompt}\n{obs_text}"
+
+    @staticmethod
+    def _extract_cmd(text: str) -> dict | None:
+        if "CMD:" not in text:
+            return None
+        cmd_text = text.split("CMD:", 1)[1].strip()
+        try:
+            return json.loads(cmd_text)
+        except json.JSONDecodeError as exc:  # invalid JSON
+            return {"error": f"CMD parse error: {exc}"}
+
+    @staticmethod
+    def _dispatch(cmd: dict) -> str:
+        if "error" in cmd:
+            return cmd["error"]
+        name = cmd.get("name")
+        if not name:
+            return "Missing tool name"
+        try:
+            spec = get_tool(name)
+        except KeyError:
+            return f"Unknown tool '{name}'"
+
+        input_data = cmd.get("input", {})
+        input_model = spec.input_model.model_validate(input_data)
+        result = spec.handler(input_model)
+        if not isinstance(result, spec.output_model):
+            result = spec.output_model.model_validate(result)
+        return result.model_dump_json()
+
+
+__all__ = ["AgentLoop"]

--- a/src/sentimental_cap_predictor/llm_core/agent/tool_registry.py
+++ b/src/sentimental_cap_predictor/llm_core/agent/tool_registry.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Type
+
+from pydantic import BaseModel
+
+
+@dataclass
+class ToolSpec:
+    """Specification for a tool callable used by the agent loop.
+
+    Attributes
+    ----------
+    name:
+        Name of the tool. Used as key within the registry.
+    input_model:
+        Pydantic model describing the expected input payload.
+    output_model:
+        Pydantic model describing the returned output payload.
+    handler:
+        Callable implementing the tool. It receives ``input_model`` and returns
+        an instance of ``output_model``.
+    """
+
+    name: str
+    input_model: Type[BaseModel]
+    output_model: Type[BaseModel]
+    handler: Callable[[BaseModel], BaseModel]
+
+
+_registry: Dict[str, ToolSpec] = {}
+"""Global mapping of tool names to their specifications."""
+
+
+def register_tool(spec: ToolSpec) -> None:
+    """Register a new tool specification.
+
+    Parameters
+    ----------
+    spec:
+        The :class:`ToolSpec` describing the tool.
+
+    Raises
+    ------
+    ValueError
+        If a tool with the same name has already been registered.
+    """
+
+    if spec.name in _registry:
+        raise ValueError(f"Tool '{spec.name}' is already registered")
+    _registry[spec.name] = spec
+
+
+def get_tool(name: str) -> ToolSpec:
+    """Retrieve a registered tool specification by name.
+
+    Parameters
+    ----------
+    name:
+        The name of the tool to look up.
+
+    Returns
+    -------
+    ToolSpec
+        The registered tool specification.
+
+    Raises
+    ------
+    KeyError
+        If the requested tool is not found in the registry.
+    """
+
+    return _registry[name]
+
+
+__all__ = ["ToolSpec", "register_tool", "get_tool"]


### PR DESCRIPTION
## Summary
- introduce a lightweight tool registry with `ToolSpec` dataclass, plus helper functions to register and fetch tools
- implement `AgentLoop` controller that parses model `CMD:` blocks, executes registered tools, and enforces step and timeout limits
- expose new agent components via package initializer for easy importing

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/agent/tool_registry.py src/sentimental_cap_predictor/llm_core/agent/loop.py src/sentimental_cap_predictor/llm_core/agent/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c203001cec832bb0d153accc9f660b