### PR TITLE
Add DuckDuckGo web search tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "lxml-html-clean>=0.4,<1",
     "protobuf<5",
     "tensorflow==2.15.0",
+    "duckduckgo-search>=5,<6",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ lxml
 cssselect
 pydantic
 colorama
+duckduckgo-search

--- a/src/sentimental_cap_predictor/llm_core/agent/__init__.py
+++ b/src/sentimental_cap_predictor/llm_core/agent/__init__.py
@@ -1,3 +1,7 @@
+"""Agent loop and tool registration utilities."""
+
+# Import built-in tools so that they register themselves on package import.
+from . import tools as _tools  # noqa: F401
 from .loop import AgentLoop
 from .tool_registry import ToolSpec, get_tool, register_tool
 

--- a/src/sentimental_cap_predictor/llm_core/agent/tools/__init__.py
+++ b/src/sentimental_cap_predictor/llm_core/agent/tools/__init__.py
@@ -1,0 +1,10 @@
+"""Tool implementations for :mod:`sentimental_cap_predictor.llm_core.agent`.
+
+Importing this module registers the built-in tools with the agent's global
+registry.
+"""
+
+# Import tools for side effects so that they register themselves.
+from . import web_search  # noqa: F401
+
+__all__ = []

--- a/src/sentimental_cap_predictor/llm_core/agent/tools/web_search.py
+++ b/src/sentimental_cap_predictor/llm_core/agent/tools/web_search.py
@@ -1,0 +1,95 @@
+"""Web search tool implementation using DuckDuckGo."""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel
+
+from ..tool_registry import ToolSpec, register_tool
+
+try:
+    from duckduckgo_search import DDGS
+except Exception:  # pragma: no cover - import time dependency errors
+    DDGS = None  # type: ignore[assignment]
+
+
+class WebSearchInput(BaseModel):
+    """Input payload for the web search tool."""
+
+    query: str
+    top_k: int = 5
+
+
+class SearchResult(BaseModel):
+    """Single search result returned by :func:`search_web`."""
+
+    title: str
+    snippet: str
+    url: str
+
+
+class WebSearchOutput(BaseModel):
+    """Output payload containing search results."""
+
+    results: List[SearchResult]
+
+
+def search_web(query: str, top_k: int = 5) -> List[dict[str, str]]:
+    """Search the web using DuckDuckGo.
+
+    Parameters
+    ----------
+    query:
+        Search terms.
+    top_k:
+        Maximum number of results to return.
+
+    Returns
+    -------
+    list of dict
+        Each dict contains ``title``, ``snippet`` and ``url`` keys.
+    """
+
+    if DDGS is None:  # pragma: no cover - runtime dependency
+        raise RuntimeError("duckduckgo_search is required for web search")
+
+    with DDGS() as ddgs:
+        raw_results = ddgs.text(query, max_results=top_k)
+
+    return [
+        {
+            "title": r.get("title", ""),
+            "snippet": r.get("body", ""),
+            "url": r.get("href", ""),
+        }
+        for r in raw_results
+    ]
+
+
+def _search_web_handler(payload: WebSearchInput) -> WebSearchOutput:
+    results = [
+        SearchResult(**res)
+        for res in search_web(
+            payload.query,
+            payload.top_k,
+        )
+    ]
+    return WebSearchOutput(results=results)
+
+
+register_tool(
+    ToolSpec(
+        name="search.web",
+        input_model=WebSearchInput,
+        output_model=WebSearchOutput,
+        handler=_search_web_handler,
+    )
+)
+
+__all__ = [
+    "WebSearchInput",
+    "SearchResult",
+    "WebSearchOutput",
+    "search_web",
+]


### PR DESCRIPTION
## Summary
- add DuckDuckGo-powered web search tool and register as `search.web`
- ensure tools auto-register on agent import
- document dependency and expose tool package

## Testing
- `pre-commit run --files pyproject.toml requirements.txt src/sentimental_cap_predictor/llm_core/agent/__init__.py src/sentimental_cap_predictor/llm_core/agent/tools/__init__.py src/sentimental_cap_predictor/llm_core/agent/tools/web_search.py`
- `pytest tests/test_reasoning_basic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2053ddb80832b8fd0a61952ac062d