### PR TITLE
Add memory tool wrappers for vector store

### DIFF
--- a/tools/memory.py
+++ b/tools/memory.py
@@ -1,0 +1,72 @@
+"""Vector store memory operations for agent tools."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from sentimental_cap_predictor.memory import vector_store
+
+
+def memory_upsert(id: str, text: str, metadata: Dict[str, Any] | None = None) -> None:
+    """Insert or update ``text`` with ``id`` and ``metadata`` in the vector store."""
+    vector_store.upsert(id, text, metadata or {})
+
+
+def memory_query(query: str, top_k: int = 5) -> List[Dict[str, Any]]:
+    """Return up to ``top_k`` matches for ``query`` from the vector store."""
+    return vector_store.query(query, k=top_k)
+
+
+__all__ = ["memory_upsert", "memory_query"]
+
+# Optional agent tool registration
+try:  # pragma: no cover - registration is optional at runtime
+    from pydantic import BaseModel, Field
+
+    from sentimental_cap_predictor.llm_core.agent.tool_registry import (
+        ToolSpec,
+        register_tool,
+    )
+
+    class MemoryUpsertInput(BaseModel):
+        id: str
+        text: str
+        metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    class MemoryUpsertOutput(BaseModel):
+        success: bool
+
+    def _memory_upsert_handler(payload: MemoryUpsertInput) -> MemoryUpsertOutput:
+        memory_upsert(payload.id, payload.text, payload.metadata)
+        return MemoryUpsertOutput(success=True)
+
+    register_tool(
+        ToolSpec(
+            name="memory.upsert",
+            input_model=MemoryUpsertInput,
+            output_model=MemoryUpsertOutput,
+            handler=_memory_upsert_handler,
+        )
+    )
+
+    class MemoryQueryInput(BaseModel):
+        query: str
+        top_k: int = 5
+
+    class MemoryQueryOutput(BaseModel):
+        results: List[Dict[str, Any]]
+
+    def _memory_query_handler(payload: MemoryQueryInput) -> MemoryQueryOutput:
+        hits = memory_query(payload.query, payload.top_k)
+        return MemoryQueryOutput(results=hits)
+
+    register_tool(
+        ToolSpec(
+            name="memory.query",
+            input_model=MemoryQueryInput,
+            output_model=MemoryQueryOutput,
+            handler=_memory_query_handler,
+        )
+    )
+except Exception:  # pragma: no cover - silently ignore registration issues
+    pass


### PR DESCRIPTION
## Summary
- add memory_upsert and memory_query helpers that delegate to existing vector_store functions
- register vector store memory operations as agent tools

## Testing
- `pre-commit run --files tools/memory.py` *(failed: no output)*
- `python3 -m py_compile tools/memory.py`
- `python3 -m pytest -q` *(failed: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eb24ba50832ba1de9c6367e7de7b