### PR TITLE
feat: secure python execution and logging

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/agent/loop.py
+++ b/src/sentimental_cap_predictor/llm_core/agent/loop.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from typing import Callable, List
 
 from .tool_registry import get_tool
+
+logger = logging.getLogger("audit")
 
 
 class AgentLoop:
@@ -89,10 +92,12 @@ class AgentLoop:
             return f"Unknown tool '{name}'"
 
         input_data = cmd.get("input", {})
+        logger.info("CMD %s input=%s", name, input_data)
         input_model = spec.input_model.model_validate(input_data)
         result = spec.handler(input_model)
         if not isinstance(result, spec.output_model):
             result = spec.output_model.model_validate(result)
+        logger.info("RESULT %s output=%s", name, result.model_dump())
         return result.model_dump_json()
 
 


### PR DESCRIPTION
## Summary
- add confirmation, logging, and size checks for file.write
- sandbox python.run with optional firejail, timeout guard, and user confirmation
- log each CMD invocation and result for auditing

## Testing
- `pre-commit run --files tools/file_io.py tools/python_exec.py src/sentimental_cap_predictor/llm_core/agent/loop.py` (fails: black/ruff-format formatting loop)
- `pytest` (fails: 37 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68c2ef8b50fc832ba2a79c7641c85672