### PR TITLE
feat: add agent mode env vars and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,18 @@ LLM_TEMPERATURE=0.7
 LLM_MAX_NEW_TOKENS=512
 # Directory for weights offloaded from device memory
 QWEN_OFFLOAD_FOLDER=
+
+# LLM provider selection
+LLM_PROVIDER=qwen_local
+DEEPSEEK_MODEL_PATH=
+DEEPSEEK_API_KEY=
+
+# Agent mode and tooling
+# Set to "1" to enable
+AGENT_MODE=
+CONFIRM_CMDS=
+ENABLE_WEB_SEARCH=0
+ENABLE_PYTHON_RUN=0
+ENABLE_FILE_WRITE=0
+ENABLE_READ_URL=0
+ENABLE_MEMORY=0

--- a/docs/agent_mode.md
+++ b/docs/agent_mode.md
@@ -1,0 +1,58 @@
+# Agent Mode
+
+Agent mode allows the chat frontend to execute registered tools through a simple
+`CMD:` protocol.  It is disabled by default and must be explicitly enabled with
+environment variables or command line flags.
+
+## Enabling
+
+1. Enable agent mode and desired tools in your `.env` file:
+
+```env
+AGENT_MODE=1
+CONFIRM_CMDS=1        # optional safety prompt
+ENABLE_WEB_SEARCH=1   # DuckDuckGo web search
+ENABLE_PYTHON_RUN=1   # sandboxed python.run tool
+ENABLE_FILE_WRITE=1   # file.write tool
+ENABLE_READ_URL=1     # read_url tool
+ENABLE_MEMORY=1       # memory.upsert and memory.query
+```
+
+2. Run the frontend with agent mode:
+
+```bash
+python -m sentimental_cap_predictor.llm_core.chatbot_frontend --agent
+```
+
+When a tool is invoked the loop logs the command and returns the tool's output
+back to the model for further reasoning.  Setting `CONFIRM_CMDS` adds a manual
+confirmation step before potentially destructive operations such as writing
+files or executing Python code.
+
+## LLM provider
+
+Any supported provider can be used in agent mode.  Select the backend via the
+`LLM_PROVIDER` variable or the `--provider` flag.  For example, to use the
+DeepSeek API:
+
+```env
+LLM_PROVIDER=deepseek
+DEEPSEEK_API_KEY=your_key_here
+```
+
+```bash
+python -m sentimental_cap_predictor.llm_core.chatbot_frontend --provider deepseek --agent
+```
+
+## Tools
+
+Available built-in tools include:
+
+- `search.web` – DuckDuckGo search
+- `python.run` – execute Python code in a sandbox
+- `file.write` – write files under `agent_work/`
+- `read_url` – fetch and extract text from a URL
+- `memory.upsert` / `memory.query` – interact with the vector memory store
+
+Additional tools can register themselves with the agent loop by calling
+`register_tool` at import time.

--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -1,8 +1,9 @@
 # Chatbot Frontend
 
-This module provides a minimal REPL interface to a **local** Qwen chat model.
+This module provides a minimal REPL interface to local or remote chat models.
 It reads configuration from environment variables (loaded with `python-dotenv`)
-and communicates with an external runner through a simple `CMD:` protocol.
+and communicates with an external runner through a simple `CMD:` protocol.  An
+experimental *agent mode* can register additional tools for the model to call.
 
 ## Environment variables
 
@@ -11,9 +12,19 @@ defaults when they are unset:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `QWEN_MODEL_PATH` | `Qwen/Qwen2-1.5B-Instruct` | Local path or HF repository for the weights |
+| `QWEN_MODEL_PATH` | `Qwen/Qwen2-1.5B-Instruct` | Local path or HF repository for Qwen weights |
 | `QWEN_OFFLOAD_FOLDER` | `(unset)` | Directory for weights offloaded from device memory |
 | `LLM_TEMPERATURE` | `0.7` | Sampling temperature |
+| `LLM_PROVIDER` | `qwen_local` | LLM backend, either `qwen_local` or `deepseek` |
+| `DEEPSEEK_MODEL_PATH` | `(unset)` | Local checkpoint for DeepSeek models |
+| `DEEPSEEK_API_KEY` | `(unset)` | API key for DeepSeek's hosted service |
+| `AGENT_MODE` | `0` | Set to `1` to enable experimental agent loop |
+| `CONFIRM_CMDS` | `0` | Require confirmation before executing tool commands |
+| `ENABLE_WEB_SEARCH` | `0` | Register DuckDuckGo search tool |
+| `ENABLE_PYTHON_RUN` | `0` | Register sandboxed Python execution tool |
+| `ENABLE_FILE_WRITE` | `0` | Allow writing files via agent tool |
+| `ENABLE_READ_URL` | `0` | Register URL reading tool |
+| `ENABLE_MEMORY` | `0` | Register vector memory tools |
 
 Variables can be placed in a `.env` file which is loaded automatically.
 
@@ -48,8 +59,10 @@ offloaded from the main device.
 ## Run
 
 ```bash
-python -m sentimental_cap_predictor.llm_core.chatbot_frontend
+python -m sentimental_cap_predictor.llm_core.chatbot_frontend --provider deepseek --agent --enable-web-search
 ```
+
+Use `--help` to see all available flags.
 
 ## CMD protocol
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,4 @@
 - [Data Bundle Format](data_bundle.md)
 - [Scheduling](scheduling.md)
 - [Research Hooks](research.md)
+- [Agent Mode](agent_mode.md)

--- a/docs/provider_args.md
+++ b/docs/provider_args.md
@@ -3,3 +3,10 @@
 ## QwenLocalProvider
 - `temperature` (float): Sampling temperature for text generation.
 - `max_new_tokens` (int, default: 512): Maximum tokens generated per reply.
+
+## DeepSeekProvider
+- `temperature` (float): Sampling temperature for text generation.
+- `max_new_tokens` (int, default: 512): Maximum tokens generated per reply.
+- `model` (str, default: `deepseek-chat`): Model ID when using the API.
+- `model_path` (str, optional): Local checkpoint path for offline usage.
+- `api_key` (str, optional): API key for DeepSeek's hosted service.


### PR DESCRIPTION
## Summary
- add configuration env vars for provider selection, DeepSeek, agent mode, and safety flags
- expose provider and agent flags in chatbot_frontend CLI with optional tool registration
- document agent setup and update existing references

## Testing
- `python -m pre_commit run --files .env.example src/sentimental_cap_predictor/llm_core/chatbot_frontend.py docs/chatbot_frontend.md docs/provider_args.md docs/agent_mode.md docs/index.md`
- `pytest -q` *(fails: No module named 'typer'; ImportError: cannot import name 'backtest_result'; ModuleNotFoundError: No module named 'loguru'; ModuleNotFoundError: No module named 'sklearn'; ModuleNotFoundError: No module named 'newspaper')*

------
https://chatgpt.com/codex/tasks/task_e_68c2f9fc5cb0832b81d4e2217d229c7e