### PR TITLE
Add comprehensive agent tests

### DIFF
--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import sentimental_cap_predictor as scp
+
+# Stub out llm_core package to avoid heavy imports
+llm_core_path = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "sentimental_cap_predictor"
+    / "llm_core"
+)
+llm_core = ModuleType("llm_core")
+llm_core.__path__ = [str(llm_core_path)]  # type: ignore[attr-defined]
+scp.llm_core = llm_core
+sys.modules["sentimental_cap_predictor.llm_core"] = llm_core

--- a/tests/agent/test_agent_loop_integration.py
+++ b/tests/agent/test_agent_loop_integration.py
@@ -1,0 +1,37 @@
+# flake8: noqa
+import json
+
+from sentimental_cap_predictor.llm_core.agent.loop import AgentLoop
+from sentimental_cap_predictor.llm_core.agent.tools import web_search
+from sentimental_cap_predictor.llm_core.llm_providers import deepseek
+
+
+def test_agent_loop_dispatch(monkeypatch):
+    def fake_search(query, top_k=5):
+        return [{"title": "T", "snippet": "S", "url": "http://x"}]
+
+    monkeypatch.setattr(web_search, "search_web", fake_search)
+
+    outputs = [
+        'Step CMD: {"name": "search.web", "input": {"query": "news"}}',
+        "Final answer",
+    ]
+
+    prompts: list[str] = []
+
+    def fake_chat(prompt: str) -> str:
+        prompts.append(prompt)
+        return outputs.pop(0)
+
+    dummy = object.__new__(deepseek.DeepSeekProvider)
+    dummy.chat = lambda messages, **kwargs: fake_chat(messages[0]["content"])  # noqa: E501
+
+    loop = AgentLoop(lambda text: dummy.chat([{"role": "user", "content": text}]))  # noqa: E501
+    result = loop.run("Hello?")
+
+    assert result == "Final answer"
+    expected_obs = json.dumps(
+        {"results": [{"title": "T", "snippet": "S", "url": "http://x"}]},
+        separators=(",", ":"),
+    )
+    assert prompts == ["Hello?", f"Hello?\nObservation: {expected_obs}"]

--- a/tests/agent/test_file_io.py
+++ b/tests/agent/test_file_io.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+from tools import file_io
+
+
+def test_file_write_success(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = file_io.file_write("out.txt", "hello")
+    assert Path(path).read_text() == "hello"
+
+
+def test_file_write_validation_error(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(file_io, "MAX_WRITE_BYTES", 1)
+    with pytest.raises(ValueError):
+        file_io.file_write("a.txt", "too long")
+
+
+def test_file_write_failure(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError):
+        file_io.file_write("../oops.txt", "hi")

--- a/tests/agent/test_golden_transcripts.py
+++ b/tests/agent/test_golden_transcripts.py
@@ -1,0 +1,137 @@
+# flake8: noqa
+import json
+
+from pydantic import BaseModel
+
+from sentimental_cap_predictor.llm_core.agent.loop import AgentLoop
+from sentimental_cap_predictor.llm_core.agent.tool_registry import (
+    ToolSpec,
+    register_tool,
+)
+from sentimental_cap_predictor.llm_core.agent.tools import web_search
+from tools import file_io, python_exec
+
+
+def test_search_read_transcript(monkeypatch):
+    def fake_search(query, top_k=5):
+        return [{"title": "A", "snippet": "B", "url": "http://example.com"}]
+
+    monkeypatch.setattr(web_search, "search_web", fake_search)
+
+    class ReadUrlInput(BaseModel):
+        url: str
+
+    class ReadUrlOutput(BaseModel):
+        text: str
+
+    def _read_handler(payload: ReadUrlInput) -> ReadUrlOutput:
+        return ReadUrlOutput(text="article text")
+
+    try:
+        register_tool(
+            ToolSpec(
+                name="read_url",
+                input_model=ReadUrlInput,
+                output_model=ReadUrlOutput,
+                handler=_read_handler,
+            )
+        )
+    except ValueError:
+        pass
+
+    outputs = [
+        'First CMD: {"name": "search.web", "input": {"query": "foo"}}',  # noqa: E501
+        ('Second CMD: {"name": "read_url", "input": {"url": "http://example.com"}}'),  # noqa: E501
+        "Final",
+    ]
+
+    prompts: list[str] = []
+
+    def fake_llm(prompt: str) -> str:
+        prompts.append(prompt)
+        return outputs.pop(0)
+
+    loop = AgentLoop(fake_llm, max_steps=3)
+    result = loop.run("Task")
+
+    assert result == "Final"
+    search_obs = json.dumps(
+        {"results": [{"title": "A", "snippet": "B", "url": "http://example.com"}]},  # noqa: E501
+        separators=(",", ":"),
+    )
+    read_obs = json.dumps({"text": "article text"}, separators=(",", ":"))
+    assert prompts == [
+        "Task",
+        f"Task\nObservation: {search_obs}",
+        f"Task\nObservation: {search_obs}\nObservation: {read_obs}",
+    ]
+
+
+def test_file_write_python_run_transcript(monkeypatch):
+    monkeypatch.setattr(
+        file_io, "file_write", lambda path, content: f"agent_work/{path}"
+    )
+    monkeypatch.setattr(
+        python_exec,
+        "python_run",
+        lambda *, code=None, path=None, timeout=10: {
+            "stdout": "ok",
+            "stderr": "",
+            "paths": [],
+        },
+    )
+
+    class PyRunInput(BaseModel):
+        code: str | None = None
+        path: str | None = None
+
+    class PyRunOutput(BaseModel):
+        stdout: str
+        stderr: str
+        paths: list[str]
+
+    def _run_handler(payload: PyRunInput) -> PyRunOutput:
+        return PyRunOutput(
+            **python_exec.python_run(code=payload.code, path=payload.path)
+        )
+
+    try:
+        register_tool(
+            ToolSpec(
+                name="python.run",
+                input_model=PyRunInput,
+                output_model=PyRunOutput,
+                handler=_run_handler,
+            )
+        )
+    except ValueError:
+        pass
+
+    outputs = [
+        (
+            'First CMD: {"name": "file.write", "input": {"path": '
+            '"script.py", "content": "print(1)"}}'
+        ),
+        'Second CMD: {"name": "python.run", "input": {"path": "script.py"}}',
+        "Done",
+    ]
+
+    prompts: list[str] = []
+
+    def fake_llm(prompt: str) -> str:
+        prompts.append(prompt)
+        return outputs.pop(0)
+
+    loop = AgentLoop(fake_llm, max_steps=3)
+    result = loop.run("Task")
+
+    assert result == "Done"
+    write_obs = json.dumps({"path": "agent_work/script.py"}, separators=(",", ":"))  # noqa: E501
+    run_obs = json.dumps(
+        {"stdout": "ok", "stderr": "", "paths": []}, separators=(",", ":")
+    )
+    assert prompts == [
+        "Task",
+        f"Task\nObservation: {write_obs}",
+        f"Task\nObservation: {write_obs}\nObservation: {run_obs}",
+    ]

--- a/tests/agent/test_python_exec.py
+++ b/tests/agent/test_python_exec.py
@@ -1,0 +1,29 @@
+import subprocess
+
+import pytest
+
+from tools import python_exec
+
+
+def test_python_run_success(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(python_exec.shutil, "which", lambda name: None)
+    result = python_exec.python_run(code="print('hi')")
+    assert result["stdout"].strip() == "hi"
+    assert result["stderr"] == ""
+
+
+def test_python_run_validation_error():
+    with pytest.raises(ValueError):
+        python_exec.python_run(code="print(1)", path="script.py")
+
+
+def test_python_run_failure(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="py", timeout=10)
+
+    monkeypatch.setattr(python_exec.subprocess, "run", fake_run)
+    with pytest.raises(subprocess.TimeoutExpired):
+        python_exec.python_run(code="print('hi')")

--- a/tests/agent/test_read_url.py
+++ b/tests/agent/test_read_url.py
@@ -1,0 +1,53 @@
+import pytest
+import requests
+
+from tools import read_url
+
+
+def test_read_url_success(monkeypatch):
+    class DummyResponse:
+        def __init__(self):
+            self.headers = {"Content-Type": "text/html"}
+            self.text = "<html><title>Hi</title><body>Hello</body></html>"
+            self.url = "http://example.com"
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda url, headers, timeout: DummyResponse(),
+    )
+    result = read_url.read_url("http://example.com")
+    assert "Hello" in result["text"]
+    assert result["meta"]["url"] == "http://example.com"
+    assert result["meta"]["title"] == "Hi"
+
+
+def test_read_url_validation_error(monkeypatch):
+    def fake_get(url, headers, timeout):
+        raise requests.exceptions.InvalidURL("bad url")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    with pytest.raises(requests.exceptions.InvalidURL):
+        read_url.read_url("not-a-url")
+
+
+def test_read_url_failure(monkeypatch):
+    class DummyResponse:
+        def __init__(self):
+            self.headers = {"Content-Type": "text/html"}
+            self.text = ""
+            self.url = "http://example.com"
+
+        def raise_for_status(self):
+            raise requests.HTTPError("404")
+
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda url, headers, timeout: DummyResponse(),
+    )
+    with pytest.raises(requests.HTTPError):
+        read_url.read_url("http://example.com")

--- a/tests/agent/test_web_search.py
+++ b/tests/agent/test_web_search.py
@@ -1,0 +1,45 @@
+import pytest
+from pydantic import ValidationError
+
+from sentimental_cap_predictor.llm_core.agent.tools import web_search
+
+
+def test_search_web_success(monkeypatch):
+    class DummyDDGS:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def text(self, query, max_results):
+            assert query == "foo"
+            assert max_results == 5
+            return [
+                {
+                    "title": "Foo",
+                    "body": "Bar",
+                    "href": "http://example.com",
+                }
+            ]
+
+    monkeypatch.setattr(web_search, "DDGS", DummyDDGS)
+    results = web_search.search_web("foo")
+    assert results == [
+        {
+            "title": "Foo",
+            "snippet": "Bar",
+            "url": "http://example.com",
+        }
+    ]
+
+
+def test_search_web_validation_error():
+    with pytest.raises(ValidationError):
+        web_search.WebSearchInput.model_validate({"top_k": 1})
+
+
+def test_search_web_failure(monkeypatch):
+    monkeypatch.setattr(web_search, "DDGS", None)
+    with pytest.raises(RuntimeError):
+        web_search.search_web("foo")


### PR DESCRIPTION
## Summary
- add unit tests for agent tools covering success, validation errors, and failures
- integrate mocked DeepSeek provider to test loop dispatching
- include golden transcript tests for multi-step tool sequences

## Testing
- `pytest tests/agent -q`
- `pre-commit run --files tests/agent/__init__.py tests/agent/conftest.py tests/agent/test_web_search.py tests/agent/test_file_io.py tests/agent/test_python_exec.py tests/agent/test_read_url.py tests/agent/test_agent_loop_integration.py tests/agent/test_golden_transcripts.py` *(fails: ruff-format keeps modifying files)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fcfca95c832bbe19ba987badcc1f