### PR TITLE
Add agent demo scripts and document risks

### DIFF
--- a/docs/agent_mode.md
+++ b/docs/agent_mode.md
@@ -56,3 +56,20 @@ Available built-in tools include:
 
 Additional tools can register themselves with the agent loop by calling
 `register_tool` at import time.
+
+## Demo scripts
+
+The `scripts` directory includes small examples demonstrating the loop:
+
+- `scripts/demo_research_url.py` – fetches and summarizes a web page.
+- `scripts/demo_python_function.py` – writes a Python function and runs it.
+- `scripts/demo_search_read_memory_code.py` – chains search, reading, memory storage, and code execution.
+
+Run them with `python <script>`.
+
+## Risks and mitigations
+
+Agent mode executes model-specified commands and has inherent risks:
+
+- **Prompt injection**: malicious text may coerce the model into unsafe actions. Keep `CONFIRM_CMDS` enabled and limit available tools.
+- **Runaway loops**: poorly behaved prompts could cause endless command cycles. The agent enforces `max_steps` and timeouts to stop runaway behavior.

--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -4,6 +4,7 @@ This module provides a minimal REPL interface to local or remote chat models.
 It reads configuration from environment variables (loaded with `python-dotenv`)
 and communicates with an external runner through a simple `CMD:` protocol.  An
 experimental *agent mode* can register additional tools for the model to call.
+By default the frontend runs the legacy Qwen conversation loop; pass `--agent` or set `AGENT_MODE=1` to enable agent mode.
 
 ## Environment variables
 

--- a/scripts/demo_python_function.py
+++ b/scripts/demo_python_function.py
@@ -1,0 +1,46 @@
+"""Demo: write and execute a Python function via agent tools."""
+from __future__ import annotations
+import importlib, pathlib, types, sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+BASE = ROOT / "src" / "sentimental_cap_predictor" / "llm_core" / "agent"
+sys.path.append(str(ROOT))  # allow importing tools
+
+pkg_root = types.ModuleType("sentimental_cap_predictor")
+sys.modules["sentimental_cap_predictor"] = pkg_root
+monitor_pkg = types.ModuleType("sentimental_cap_predictor.monitoring")
+class RunLogger:
+    def log(self, **kwargs):
+        pass
+monitor_pkg.RunLogger = RunLogger
+sys.modules["sentimental_cap_predictor.monitoring"] = monitor_pkg
+llm_pkg = types.ModuleType("sentimental_cap_predictor.llm_core")
+sys.modules["sentimental_cap_predictor.llm_core"] = llm_pkg
+agent_pkg = types.ModuleType("sentimental_cap_predictor.llm_core.agent")
+agent_pkg.__path__ = [str(BASE)]
+sys.modules["sentimental_cap_predictor.llm_core.agent"] = agent_pkg
+
+loop_mod = importlib.import_module("sentimental_cap_predictor.llm_core.agent.loop")
+AgentLoop = loop_mod.AgentLoop
+
+from tools import file_io, python_exec  # noqa: F401 - ensure tool registration
+
+RESPONSES = [
+    'CMD: {"name": "file.write", "input": {"path": "demo.py", "content": "def add(a,b):\n    return a+b\nprint(add(2,3))"}}',
+    'CMD: {"name": "python.run", "input": {"path": "demo.py"}}',
+    "Finished running the function.",
+]
+
+
+def _fake_llm(_prompt: str) -> str:
+    return RESPONSES.pop(0)
+
+
+def main() -> None:
+    loop = AgentLoop(_fake_llm, max_steps=3)
+    result = loop.run("Write a Python function and execute it")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo_research_url.py
+++ b/scripts/demo_research_url.py
@@ -1,0 +1,73 @@
+"""Demo: research and summarize a URL using agent tools."""
+from __future__ import annotations
+import importlib, pathlib, types, sys
+
+BASE = pathlib.Path(__file__).resolve().parents[1] / "src" / "sentimental_cap_predictor" / "llm_core" / "agent"
+
+# Stub package hierarchy to satisfy relative imports
+pkg_root = types.ModuleType("sentimental_cap_predictor")
+sys.modules["sentimental_cap_predictor"] = pkg_root
+monitor_pkg = types.ModuleType("sentimental_cap_predictor.monitoring")
+class RunLogger:  # minimal stub
+    def log(self, **kwargs):
+        pass
+monitor_pkg.RunLogger = RunLogger
+sys.modules["sentimental_cap_predictor.monitoring"] = monitor_pkg
+llm_pkg = types.ModuleType("sentimental_cap_predictor.llm_core")
+sys.modules["sentimental_cap_predictor.llm_core"] = llm_pkg
+agent_pkg = types.ModuleType("sentimental_cap_predictor.llm_core.agent")
+agent_pkg.__path__ = [str(BASE)]
+sys.modules["sentimental_cap_predictor.llm_core.agent"] = agent_pkg
+
+loop_mod = importlib.import_module("sentimental_cap_predictor.llm_core.agent.loop")
+AgentLoop = loop_mod.AgentLoop
+reg_mod = importlib.import_module("sentimental_cap_predictor.llm_core.agent.tool_registry")
+ToolSpec = reg_mod.ToolSpec
+register_tool = reg_mod.register_tool
+
+from pydantic import BaseModel
+
+
+class ReadUrlInput(BaseModel):
+    url: str
+
+
+class ReadUrlOutput(BaseModel):
+    text: str
+
+
+def _read_url(payload: ReadUrlInput) -> ReadUrlOutput:
+    return ReadUrlOutput(text="Example Domain is for use in illustrative examples.")
+
+
+try:  # pragma: no cover - registration is optional
+    register_tool(
+        ToolSpec(
+            name="read_url",
+            input_model=ReadUrlInput,
+            output_model=ReadUrlOutput,
+            handler=_read_url,
+        )
+    )
+except ValueError:
+    pass
+
+
+RESPONSES = [
+    'CMD: {"name": "read_url", "input": {"url": "http://example.com"}}',
+    "The page describes the Example Domain, a site for demonstrations.",
+]
+
+
+def _fake_llm(_prompt: str) -> str:
+    return RESPONSES.pop(0)
+
+
+def main() -> None:
+    loop = AgentLoop(_fake_llm, max_steps=2)
+    result = loop.run("Summarize http://example.com")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo_search_read_memory_code.py
+++ b/scripts/demo_search_read_memory_code.py
@@ -1,0 +1,133 @@
+"""Demo: chain search -> read -> memory -> code -> answer."""
+from __future__ import annotations
+import importlib, pathlib, types, sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+BASE = ROOT / "src" / "sentimental_cap_predictor" / "llm_core" / "agent"
+sys.path.append(str(ROOT))
+
+pkg_root = types.ModuleType("sentimental_cap_predictor")
+sys.modules["sentimental_cap_predictor"] = pkg_root
+monitor_pkg = types.ModuleType("sentimental_cap_predictor.monitoring")
+class RunLogger:
+    def log(self, **kwargs):
+        pass
+monitor_pkg.RunLogger = RunLogger
+sys.modules["sentimental_cap_predictor.monitoring"] = monitor_pkg
+llm_pkg = types.ModuleType("sentimental_cap_predictor.llm_core")
+sys.modules["sentimental_cap_predictor.llm_core"] = llm_pkg
+agent_pkg = types.ModuleType("sentimental_cap_predictor.llm_core.agent")
+agent_pkg.__path__ = [str(BASE)]
+sys.modules["sentimental_cap_predictor.llm_core.agent"] = agent_pkg
+
+loop_mod = importlib.import_module("sentimental_cap_predictor.llm_core.agent.loop")
+AgentLoop = loop_mod.AgentLoop
+reg_mod = importlib.import_module("sentimental_cap_predictor.llm_core.agent.tool_registry")
+ToolSpec = reg_mod.ToolSpec
+register_tool = reg_mod.register_tool
+
+from pydantic import BaseModel, Field
+from tools import python_exec  # noqa: F401 - ensure python.run registration
+
+
+class SearchInput(BaseModel):
+    query: str
+    top_k: int = 5
+
+
+class SearchOutput(BaseModel):
+    results: list[dict[str, str]]
+
+
+def _search(payload: SearchInput) -> SearchOutput:
+    return SearchOutput(
+        results=[{"title": "Example", "snippet": "Demo page", "url": "http://example.com"}]
+    )
+
+
+try:
+    register_tool(
+        ToolSpec(
+            name="search.web",
+            input_model=SearchInput,
+            output_model=SearchOutput,
+            handler=_search,
+        )
+    )
+except ValueError:
+    pass
+
+
+class ReadInput(BaseModel):
+    url: str
+
+
+class ReadOutput(BaseModel):
+    text: str
+
+
+def _read(payload: ReadInput) -> ReadOutput:
+    return ReadOutput(text="Example Domain text")
+
+
+try:
+    register_tool(
+        ToolSpec(
+            name="read_url",
+            input_model=ReadInput,
+            output_model=ReadOutput,
+            handler=_read,
+        )
+    )
+except ValueError:
+    pass
+
+
+class UpsertInput(BaseModel):
+    id: str
+    text: str
+    metadata: dict = Field(default_factory=dict)
+
+
+class UpsertOutput(BaseModel):
+    success: bool
+
+
+def _upsert(payload: UpsertInput) -> UpsertOutput:
+    return UpsertOutput(success=True)
+
+
+try:
+    register_tool(
+        ToolSpec(
+            name="memory.upsert",
+            input_model=UpsertInput,
+            output_model=UpsertOutput,
+            handler=_upsert,
+        )
+    )
+except ValueError:
+    pass
+
+
+RESPONSES = [
+    'CMD: {"name": "search.web", "input": {"query": "demo"}}',
+    'CMD: {"name": "read_url", "input": {"url": "http://example.com"}}',
+    'CMD: {"name": "memory.upsert", "input": {"id": "ex", "text": "Example Domain text", "metadata": {"url": "http://example.com"}}}',
+    'CMD: {"name": "python.run", "input": {"code": "print(6*7)"}}',
+    "Stored info and computed result 42.",
+]
+
+
+def _fake_llm(_prompt: str) -> str:
+    return RESPONSES.pop(0)
+
+
+def main() -> None:
+    loop = AgentLoop(_fake_llm, max_steps=5)
+    result = loop.run("Find info, store it, run code, and answer")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_opt_in.py
+++ b/tests/test_agent_opt_in.py
@@ -1,0 +1,70 @@
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _load_frontend():
+    sys.modules["faiss"] = types.ModuleType("faiss")
+    sys.modules["torch"] = types.ModuleType("torch")
+    dummy_trans = types.ModuleType("transformers")
+    class AutoModel:
+        pass
+    class AutoTokenizer:
+        pass
+    dummy_trans.AutoModel = AutoModel
+    dummy_trans.AutoTokenizer = AutoTokenizer
+    sys.modules["transformers"] = dummy_trans
+    dummy_dotenv = types.ModuleType("dotenv")
+    dummy_dotenv.load_dotenv = lambda *a, **k: None
+    sys.modules["dotenv"] = dummy_dotenv
+
+    dummy_news = types.ModuleType("sentimental_cap_predictor.data.news")
+    @dataclass
+    class FetchArticleSpec:
+        query: str = ""
+    dummy_news.FetchArticleSpec = FetchArticleSpec
+    dummy_news.fetch_first_gdelt_article = lambda *a, **k: None
+    dummy_news.fetch_article = lambda *a, **k: None
+    dummy_data = types.ModuleType("sentimental_cap_predictor.data")
+    dummy_data.__path__ = []
+    dummy_data.news = dummy_news
+    sys.modules["sentimental_cap_predictor.data"] = dummy_data
+    sys.modules["sentimental_cap_predictor.data.news"] = dummy_news
+
+    spec = importlib.util.spec_from_file_location(
+        "chatbot_frontend",
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "sentimental_cap_predictor"
+        / "llm_core"
+        / "chatbot_frontend.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_agent_disabled_by_default(monkeypatch):
+    cf = _load_frontend()
+    monkeypatch.delenv("AGENT_MODE", raising=False)
+    monkeypatch.setattr(sys, "argv", ["prog"])
+    args = cf._parse_args()
+    assert args.agent is False
+
+
+def test_agent_enabled_via_flag(monkeypatch):
+    cf = _load_frontend()
+    monkeypatch.delenv("AGENT_MODE", raising=False)
+    monkeypatch.setattr(sys, "argv", ["prog", "--agent"])
+    args = cf._parse_args()
+    assert args.agent is True
+
+
+def test_agent_enabled_via_env(monkeypatch):
+    cf = _load_frontend()
+    monkeypatch.setenv("AGENT_MODE", "1")
+    monkeypatch.setattr(sys, "argv", ["prog"])
+    args = cf._parse_args()
+    assert args.agent is True


### PR DESCRIPTION
## Summary
- keep Qwen REPL default and document opt-in agent mode
- add demo scripts for URL research, Python execution, and multi-step search/memory/code
- outline agent risks and mitigations

## Testing
- `python scripts/demo_research_url.py`
- `python scripts/demo_python_function.py`
- `python scripts/demo_search_read_memory_code.py`
- `pytest tests/test_agent_opt_in.py`


------
https://chatgpt.com/codex/tasks/task_e_68c308165dcc832ba75588bf8353f7d5