### PR TITLE
Register read.url agent tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ format:
 	pre-commit run ruff-format --all-files
 
 test:
-        pytest
+	pytest

--- a/docs/agent_mode.md
+++ b/docs/agent_mode.md
@@ -14,7 +14,7 @@ CONFIRM_CMDS=1        # optional safety prompt
 ENABLE_WEB_SEARCH=1   # DuckDuckGo web search
 ENABLE_PYTHON_RUN=1   # sandboxed python.run tool
 ENABLE_FILE_WRITE=1   # file.write tool
-ENABLE_READ_URL=1     # read_url tool
+ENABLE_READ_URL=1     # read.url tool
 ENABLE_MEMORY=1       # memory.upsert and memory.query
 ```
 
@@ -51,7 +51,7 @@ Available built-in tools include:
 - `search.web` – DuckDuckGo search
 - `python.run` – execute Python code in a sandbox
 - `file.write` – write files under `agent_work/`
-- `read_url` – fetch and extract text from a URL
+- `read.url` – fetch and extract text from a URL
 - `memory.upsert` / `memory.query` – interact with the vector memory store
 
 Additional tools can register themselves with the agent loop by calling

--- a/scripts/demo_python_function.py
+++ b/scripts/demo_python_function.py
@@ -26,8 +26,8 @@ AgentLoop = loop_mod.AgentLoop
 from tools import file_io, python_exec  # noqa: F401 - ensure tool registration
 
 RESPONSES = [
-    'CMD: {"name": "file.write", "input": {"path": "demo.py", "content": "def add(a,b):\n    return a+b\nprint(add(2,3))"}}',
-    'CMD: {"name": "python.run", "input": {"path": "demo.py"}}',
+    'CMD: {"tool": "file.write", "input": {"path": "demo.py", "content": "def add(a,b):\n    return a+b\nprint(add(2,3))"}}',
+    'CMD: {"tool": "python.run", "input": {"path": "demo.py"}}',
     "Finished running the function.",
 ]
 

--- a/scripts/demo_research_url.py
+++ b/scripts/demo_research_url.py
@@ -43,7 +43,7 @@ def _read_url(payload: ReadUrlInput) -> ReadUrlOutput:
 try:  # pragma: no cover - registration is optional
     register_tool(
         ToolSpec(
-            name="read_url",
+            name="read.url",
             input_model=ReadUrlInput,
             output_model=ReadUrlOutput,
             handler=_read_url,
@@ -54,7 +54,7 @@ except ValueError:
 
 
 RESPONSES = [
-    'CMD: {"name": "read_url", "input": {"url": "http://example.com"}}',
+    'CMD: {"tool": "read.url", "input": {"url": "http://example.com"}}',
     "The page describes the Example Domain, a site for demonstrations.",
 ]
 

--- a/scripts/demo_search_read_memory_code.py
+++ b/scripts/demo_search_read_memory_code.py
@@ -73,7 +73,7 @@ def _read(payload: ReadInput) -> ReadOutput:
 try:
     register_tool(
         ToolSpec(
-            name="read_url",
+            name="read.url",
             input_model=ReadInput,
             output_model=ReadOutput,
             handler=_read,
@@ -111,10 +111,10 @@ except ValueError:
 
 
 RESPONSES = [
-    'CMD: {"name": "search.web", "input": {"query": "demo"}}',
-    'CMD: {"name": "read_url", "input": {"url": "http://example.com"}}',
-    'CMD: {"name": "memory.upsert", "input": {"id": "ex", "text": "Example Domain text", "metadata": {"url": "http://example.com"}}}',
-    'CMD: {"name": "python.run", "input": {"code": "print(6*7)"}}',
+    'CMD: {"tool": "search.web", "input": {"query": "demo"}}',
+    'CMD: {"tool": "read.url", "input": {"url": "http://example.com"}}',
+    'CMD: {"tool": "memory.upsert", "input": {"id": "ex", "text": "Example Domain text", "metadata": {"url": "http://example.com"}}}',
+    'CMD: {"tool": "python.run", "input": {"code": "print(6*7)"}}',
     "Stored info and computed result 42.",
 ]
 

--- a/src/sentimental_cap_predictor/llm_core/agent/loop.py
+++ b/src/sentimental_cap_predictor/llm_core/agent/loop.py
@@ -76,7 +76,7 @@ class AgentLoop:
             model_output = self._llm(model_input)
 
             cmd = self._extract_cmd(model_output)
-            tool_name = cmd.get("name") if isinstance(cmd, dict) else None
+            tool_name = cmd.get("tool") if isinstance(cmd, dict) else None
             error = cmd.get("error") if isinstance(cmd, dict) and "error" in cmd else None
 
             if cmd is None:
@@ -171,21 +171,21 @@ class AgentLoop:
     def _dispatch(cmd: dict) -> str:
         if "error" in cmd:
             return cmd["error"]
-        name = cmd.get("name")
-        if not name:
+        tool = cmd.get("tool")
+        if not tool:
             return "Missing tool name"
         try:
-            spec = get_tool(name)
+            spec = get_tool(tool)
         except KeyError:
-            return f"Unknown tool '{name}'"
+            return f"Unknown tool '{tool}'"
 
         input_data = cmd.get("input", {})
-        logger.info("CMD %s input=%s", name, input_data)
+        logger.info("CMD %s input=%s", tool, input_data)
         input_model = spec.input_model.model_validate(input_data)
         result = spec.handler(input_model)
         if not isinstance(result, spec.output_model):
             result = spec.output_model.model_validate(result)
-        logger.info("RESULT %s output=%s", name, result.model_dump())
+        logger.info("RESULT %s output=%s", tool, result.model_dump())
         return result.model_dump_json()
 
 

--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -92,7 +92,7 @@ def _parse_args() -> argparse.Namespace:
         "--enable-read-url",
         action="store_true",
         default=os.getenv("ENABLE_READ_URL") not in {None, "", "0"},
-        help="Register read_url tool",
+        help="Register read.url tool",
     )
     parser.add_argument(
         "--enable-memory",

--- a/tests/agent/test_agent_loop_integration.py
+++ b/tests/agent/test_agent_loop_integration.py
@@ -13,7 +13,7 @@ def test_agent_loop_dispatch(monkeypatch):
     monkeypatch.setattr(web_search, "search_web", fake_search)
 
     outputs = [
-        'Step CMD: {"name": "search.web", "input": {"query": "news"}}',
+        'Step CMD: {"tool": "search.web", "input": {"query": "news"}}',
         "Final answer",
     ]
 

--- a/tests/agent/test_read_url.py
+++ b/tests/agent/test_read_url.py
@@ -22,7 +22,7 @@ def test_read_url_success(monkeypatch):
     result = read_url.read_url("http://example.com")
     assert "Hello" in result["text"]
     assert result["meta"]["url"] == "http://example.com"
-    assert result["meta"]["title"] == "Hi"
+    assert result["meta"].get("title") == "Hi"
 
 
 def test_read_url_validation_error(monkeypatch):

--- a/tests/test_run_logger.py
+++ b/tests/test_run_logger.py
@@ -8,7 +8,8 @@ from sentimental_cap_predictor.monitoring import RunLogger
 def test_agent_loop_writes_run_log(tmp_path, monkeypatch):
     rl = RunLogger(base_dir=tmp_path)
 
-    loop = AgentLoop(lambda _: 'CMD: {"name": "dummy"}', max_steps=1)
+    responses = ['CMD: {"tool": "dummy"}', "done"]
+    loop = AgentLoop(lambda _: responses.pop(0), max_steps=2)
     loop._run_logger = rl
 
     monkeypatch.setattr(AgentLoop, "_dispatch", lambda self, cmd: "ok")


### PR DESCRIPTION
## Summary
- switch CMD payloads to `{"tool": ...}` and update agent loop accordingly
- add regex-based title fallback in `read_url` so extraction works without `lxml`
- update docs, demos, and tests to use `read.url` name and new CMD format
- fix Makefile test target indentation so `make` runs

## Testing
- `make install` *(fails: pip: not found)*
- `python3 -m pytest tests/agent/test_read_url.py tests/agent/test_golden_transcripts.py tests/agent/test_agent_loop_integration.py tests/test_run_logger.py` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68c1eb061550832b8cdbba894452847f