### PR TITLE
Log readability-lxml hint and document optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ flowchart TD
    ```bash
    pip install -e .[dev]
    ```
+   Optional but recommended for improved article parsing:
+
+   ```bash
+   pip install readability-lxml
+   ```
 3. **Collect data**
    ```bash
    python -m sentimental_cap_predictor.dataset TICKER --period 1Y


### PR DESCRIPTION
## Summary
- hint that installing `readability-lxml` improves article parsing when `readability` is missing
- document optional `readability-lxml` dependency in README with installation instructions

## Testing
- `~/.pyenv/versions/3.11.12/bin/pre-commit run --files README.md src/sentimental_cap_predictor/news/article_reader.py`
- `~/.pyenv/versions/3.11.12/bin/pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68c324afc050832b981369084836f7c1