### PR TITLE
Handle empty article responses in news CLI

### DIFF
--- a/src/sentimental_cap_predictor/news/cli.py
+++ b/src/sentimental_cap_predictor/news/cli.py
@@ -65,7 +65,27 @@ def read_command(
 ) -> None:
     """Read an article and optionally process it."""
     html = fetch_html(url)
-    text = strip_ads(extract_main(html, url=url))
+    if not html:
+        message = (
+            "Failed to fetch article from "
+            + url
+            + ". "
+            + "Please retry or check network access."
+        )
+        typer.echo(message)
+        raise typer.Exit(code=1)
+
+    extracted = extract_main(html, url=url)
+    if not extracted.strip():
+        message = (
+            "Failed to extract article text from "
+            f"{url}. "
+            "Please retry or check network access."
+        )
+        typer.echo(message)
+        raise typer.Exit(code=1)
+
+    text = strip_ads(extracted)
     original_text = text
 
     analysis = None


### PR DESCRIPTION
## Summary
- add user-friendly error handling when fetching or extracting article text fails in CLI

## Testing
- `.venv/bin/pre-commit run --files src/sentimental_cap_predictor/news/cli.py`
- `.venv/bin/pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c33913a0b0832b8db324694214d3db