### PR TITLE
Allow filler words in article fetch

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -537,7 +537,7 @@ def _route_keywords(message: str) -> Callable[[], str] | None:
     import re
 
     m = re.search(
-        r"(?:pull up|fetch|get) (?:an? )?article(?: (?:about|on) (?P<topic>.+))?",
+        r"(?:pull up|fetch|get) (?:an? )?article(?:.*?(?:about|on) (?P<topic>.+))?",
         message,
         re.I,
     )

--- a/tests/test_chatbot_frontend.py
+++ b/tests/test_chatbot_frontend.py
@@ -618,6 +618,22 @@ def test_route_keywords_fetch_variants(monkeypatch):
     assert handler() == "What topic should I search for?"
 
 
+def test_route_keywords_fetch_with_filler(monkeypatch):
+    cf._LAST_ARTICLE_URL = None
+    captured = {}
+
+    def fake_fetch(topic):  # noqa: ANN001
+        captured["topic"] = topic
+        return "text"
+
+    monkeypatch.setattr(cf, "fetch_first_gdelt_article", fake_fetch)
+
+    handler = cf._route_keywords("pull up an article for me about Charlie Kirk")
+    assert handler is not None
+    assert handler() == "text"
+    assert captured["topic"] == "Charlie Kirk"
+
+
 def test_route_keywords_read_summarize_and_search(monkeypatch):
     cf._LAST_ARTICLE_URL = "http://a"
 


### PR DESCRIPTION
## Summary
- relax article fetch regex to allow filler words before topic
- test keyword routing supports phrases like `pull up an article for me about Charlie Kirk`

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/llm_core/chatbot_frontend.py tests/test_chatbot_frontend.py`
- `python3 -m pytest tests/test_chatbot_frontend.py -k fetch_with_filler -q`


------
https://chatgpt.com/codex/tasks/task_e_68c34f0613ec832b90378bc2ce39dfa4