### PR TITLE
Add regex fallback for Qwen classification failure

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
+++ b/src/sentimental_cap_predictor/llm_core/chatbot_frontend.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Callable
 
@@ -663,15 +664,13 @@ def _classify_and_route(message: str) -> str | None:
 
     try:
         text = qwen_intent.call_qwen(message)
-    except Exception:  # pragma: no cover - model failure
-        return None
-
-    m = qwen_intent._JSON_RE.search(text or "")  # type: ignore[attr-defined]
-    if not m:
-        return None
-    try:
+        m = qwen_intent._JSON_RE.search(text or "")  # type: ignore[attr-defined]
+        if not m:
+            raise ValueError("no json")
         data = json.loads(m.group(1))
-    except json.JSONDecodeError:
+    except Exception:  # model or parsing failure
+        if re.match(r"^[\w\s]+$", message):
+            return fetch_first_gdelt_article(message)
         return None
 
     intent = data.get("intent")


### PR DESCRIPTION
## Summary
- add `re.match` fallback to treat text as info.lookup when Qwen classification or JSON parsing fails
- return GDELT article when fallback triggers

## Testing
- `python3 -m pre_commit run --files src/sentimental_cap_predictor/llm_core/chatbot_frontend.py` *(fails: No module named pre_commit)*
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68c354054368832ba4cb33d92bcabc57