### PR TITLE
feat(news): translate summaries by default

### DIFF
--- a/tests/test_news_cli.py
+++ b/tests/test_news_cli.py
@@ -122,7 +122,42 @@ def test_read_cli(monkeypatch):
     )
     assert result.exit_code == 0
     data = json.loads(result.stdout.strip())
-    assert data["text"] == "translated"
+    assert data["text"] == "body"
     assert data["summary"] == "summary"
     assert data["analysis"]["lang"] == "en"
     assert data["chunks"] == ["chunk"]
+
+
+def test_read_cli_summarize_non_english(monkeypatch):
+    runner = CliRunner()
+
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.fetch_html",
+        lambda url: "<html></html>",
+    )
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.extract_main",
+        lambda html, url=None: "cuerpo",
+    )
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.analyze_text",
+        lambda text: {"lang": "es", "word_count": 1},
+    )
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.summarize_text",
+        lambda text: text,
+    )
+    monkeypatch.setattr(
+        "sentimental_cap_predictor.news.cli.translate_text",
+        lambda text, target_lang: "translated",
+    )
+
+    result = runner.invoke(
+        app,
+        ["read", "--url", "http://example.com", "--summarize"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout.strip())
+    assert data["text"] == "cuerpo"
+    assert data["summary"] == "translated"


### PR DESCRIPTION
## Summary
- ensure non-English articles are translated before summarization when translate mode is off
- document automatic summary translation in CLI help
- add CLI test for non-English summaries

## Testing
- `PYENV_VERSION=3.11.12 pytest tests/test_news_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68c362b4bfb0832bb4ba3148674d2e94