### PR TITLE
feat: make sentiment model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ flowchart TD
    ```bash
    python -m sentimental_cap_predictor.modeling.sentiment_analysis <NEWS_PATH>
    ```
+   The news reader uses the
+   `distilbert/distilbert-base-uncased-finetuned-sst-2-english` model by
+   default for sentiment analysis. Override this choice by setting the
+   `SENTIMENT_MODEL` environment variable to another Hugging Face repository
+   id.
 
 ## Typer CLI Usage
 Each module exposes a Typer application:

--- a/src/sentimental_cap_predictor/config.py
+++ b/src/sentimental_cap_predictor/config.py
@@ -73,6 +73,11 @@ SEASONAL_ORDER = tuple(
 PREDICTION_DAYS = int(os.getenv("PREDICTION_DAYS", 14))
 TRAIN_SIZE_RATIO = float(os.getenv("TRAIN_SIZE_RATIO", 0.8))
 
+# Default model for sentiment analysis
+SENTIMENT_MODEL = os.getenv(
+    "SENTIMENT_MODEL", "distilbert/distilbert-base-uncased-finetuned-sst-2-english"
+)
+
 # Data path
 DATA_PATH = os.getenv("DATA_PATH", "./data/your_data.csv")
 


### PR DESCRIPTION
## Summary
- allow `SENTIMENT_MODEL` env var to control which transformers model is used for sentiment
- avoid running sentiment pipeline unless explicitly requested
- document default model and configuration override in README

## Testing
- `python3 -m py_compile src/sentimental_cap_predictor/config.py src/sentimental_cap_predictor/news/article_reader.py`
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68c3650517bc832b9ed1f88723e5424f