### PR TITLE
feat: direct summary output for news CLI

### DIFF
--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -93,12 +93,13 @@ Utilities from the news CLI can be accessed through `CMD:` directives:
 
 ```bash
 CMD: news.fetch_gdelt --query "<terms>" --max 1
-CMD: news.read --url "<article_url>" --summarize --analyze --chunks 1000
+CMD: news.read --url "<article_url>" --summarize --analyze --chunks 1000 --json
 ```
 
 The first command returns matching GDELT articles as JSON. The second retrieves
 an article, summarises it, performs a basic analysis and optionally chunks the
-text for further processing.
+text for further processing. When `--summarize` is used on its own, the
+response is the summary text; add `--json` to get a JSON object instead.
 
 ## Connector intents
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -105,8 +105,12 @@ Basic news helpers are available through the chatbot's command interface:
 
 ```bash
 CMD: news.fetch_gdelt --query "<terms>" --max 1
-CMD: news.read --url "<article_url>" --summarize --analyze --chunks 1000
+CMD: news.read --url "<article_url>" --summarize --analyze --chunks 1000 --json
 ```
+
+When `--summarize` is supplied without other processing flags, `news.read`
+prints only the summary text. Add `--json` to receive the response as a JSON
+object instead.
 
 ## GitHub Repository Data
 


### PR DESCRIPTION
## Summary
- print summary text directly when `news.read` runs with only `--summarize`
- add `--json` flag to keep JSON output when desired
- document new `news.read` behaviour and `--json` option

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/news/cli.py docs/cli.md docs/chatbot_frontend.md` *(fails: command not found)*
- `pytest` *(fails: pyenv version `3.11.9` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3680a41cc832b9700e5524867af77