### PR TITLE
Normalize language codes for news filtering

### DIFF
--- a/src/sentimental_cap_predictor/data/news.py
+++ b/src/sentimental_cap_predictor/data/news.py
@@ -201,10 +201,15 @@ def is_valid_candidate(article: pd.Series, spec: FetchArticleSpec) -> bool:
     title = str(article.get("title") or article.get("headline") or "")
     url = str(article.get("url") or "")
     article_language = str(article.get("language") or "").lower()
+    spec_language = str(spec.language or "").lower()
+
+    # Treat ISO codes and full language names as equivalent by comparing the
+    # first two characters of each.  This allows values like ``"en"`` and
+    # ``"english"`` to match while still rejecting mismatched languages.
+    article_lang_code = article_language[:2]
+    spec_lang_code = spec_language[:2]
     language_mismatch = (
-        spec.language
-        and article_language
-        and (article_language != spec.language.lower())
+        spec_language and article_lang_code and (article_lang_code != spec_lang_code)
     )
     if language_mismatch:
         return False

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -400,3 +400,13 @@ def test_fetch_article_skips_non_english(monkeypatch):
     article = news.fetch_article(spec)
     assert article.url == "http://en.com"
     assert extracted == ["http://en.com"]
+
+
+@pytest.mark.parametrize(
+    "spec_lang, article_lang",
+    [("english", "en"), ("en", "english")],
+)
+def test_is_valid_candidate_accepts_language_variants(spec_lang, article_lang):
+    article = pd.Series({"title": "Headline", "url": "http://example.com", "language": article_lang})
+    spec = news.FetchArticleSpec(query="q", language=spec_lang)
+    assert news.is_valid_candidate(article, spec)


### PR DESCRIPTION
## Summary
- treat ISO language codes and names equivalently when validating news articles
- add regression tests ensuring English articles pass for both 'en' and 'english'

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_news.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c377d59910832bad07367fa9b6c26a