### PR TITLE
Handle missing translator gracefully

### DIFF
--- a/src/sentimental_cap_predictor/news/article_reader.py
+++ b/src/sentimental_cap_predictor/news/article_reader.py
@@ -267,17 +267,17 @@ def summarize(text: str, max_sentences: int = 3) -> str:
     return " ".join(sentences[:max_sentences])
 
 
-def translate(text: str, target_lang: str) -> str:
+def translate(text: str, target_lang: str) -> str | None:
     """Attempt to translate ``text`` into ``target_lang``.
 
-    If a translation library is not available this function returns the string
-    ``"Translation disabled"``.
+    If a translation library is not available or translation fails, ``None`` is
+    returned.
     """
 
     try:  # pragma: no cover - optional dependency
         from googletrans import Translator
     except Exception:
-        return "Translation disabled"
+        return None
 
     try:  # pragma: no cover - translation may fail at runtime
         translator = Translator()
@@ -285,4 +285,4 @@ def translate(text: str, target_lang: str) -> str:
         return result.text
     except Exception as exc:
         logger.warning("Translation failed: %s", exc)
-        return "Translation disabled"
+        return None

--- a/src/sentimental_cap_predictor/news/cli.py
+++ b/src/sentimental_cap_predictor/news/cli.py
@@ -117,7 +117,11 @@ def read_command(
 
     if translate in (TranslateMode.auto, TranslateMode.en) and analysis:
         if analysis.get("lang") != "en":
-            text = translate_text(text, "en")
+            translated = translate_text(text, "en")
+            if translated is None:
+                typer.echo("Translation unavailable; using original text.")
+            else:
+                text = translated
 
     summary_text = text
     if (
@@ -126,7 +130,12 @@ def read_command(
         and analysis
         and analysis.get("lang") != "en"
     ):
-        summary_text = translate_text(text, "en")
+        summary_translation = translate_text(text, "en")
+        if summary_translation is None:
+            typer.echo("Translation unavailable; using original text.")
+            summary_text = text
+        else:
+            summary_text = summary_translation
     summary_only = (
         summarize
         and not analyze


### PR DESCRIPTION
## Summary
- Return `None` when translation cannot be performed
- Warn and fall back to original text when translation results are unavailable
- Test CLI behavior when translator is missing

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_article_reader.py::test_translate_returns_none_when_library_missing tests/test_news_cli.py::test_read_cli_translation_missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68c380b67130832ba885ff39ef228f25