### PR TITLE
Handle translation failures in news CLI

### DIFF
--- a/src/sentimental_cap_predictor/news/cli.py
+++ b/src/sentimental_cap_predictor/news/cli.py
@@ -117,7 +117,11 @@ def read_command(
 
     if translate in (TranslateMode.auto, TranslateMode.en) and analysis:
         if analysis.get("lang") != "en":
-            text = translate_text(text, "en")
+            translated = translate_text(text, "en")
+            if not translated or translated == "Translation disabled":
+                typer.echo("Warning: translation unavailable; using original text.", err=True)
+            else:
+                text = translated
 
     summary_text = text
     if (
@@ -126,7 +130,14 @@ def read_command(
         and analysis
         and analysis.get("lang") != "en"
     ):
-        summary_text = translate_text(text, "en")
+        translated = translate_text(text, "en")
+        if not translated or translated == "Translation disabled":
+            typer.echo(
+                "Warning: translation unavailable; using original text for summary.",
+                err=True,
+            )
+        else:
+            summary_text = translated
     summary_only = (
         summarize
         and not analyze


### PR DESCRIPTION
## Summary
- gracefully fall back to original article text when translation fails
- warn the user when translation isn't available
- test CLI behavior for translation failure scenarios

## Testing
- `python -m pytest tests/test_news_cli.py`
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68c380e77f40832b843e811756c2a5d9