### PR TITLE
Refactor GDELT fetcher and configurable domain policy

### DIFF
--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -101,6 +101,9 @@ an article, summarises it, performs a basic analysis and optionally chunks the
 text for further processing. When `--summarize` is used on its own, the
 response is the summary text; add `--json` to get a JSON object instead.
 
+Domain allow/block lists for GDELT results can be supplied through the
+`NEWS_ALLOWED_DOMAINS` and `NEWS_BLOCKED_DOMAINS` environment variables.
+
 ## Connector intents
 
 The chatbot understands simple phrases to pull data from a few external

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -112,6 +112,9 @@ When `--summarize` is supplied without other processing flags, `news.read`
 prints only the summary text. Add `--json` to receive the response as a JSON
 object instead.
 
+GDELT domain filters can be configured via the `NEWS_ALLOWED_DOMAINS` and
+`NEWS_BLOCKED_DOMAINS` environment variables (comma-separated lists).
+
 ## GitHub Repository Data
 
 Utilities that pull information from the GitHub API can optionally use a

--- a/tests/test_news_cli.py
+++ b/tests/test_news_cli.py
@@ -25,6 +25,7 @@ dummy_pkg.news = dummy_news_pkg
 
 dummy_config = types.ModuleType("sentimental_cap_predictor.config")
 dummy_config.GDELT_API_URL = "https://example.com"
+dummy_config.SENTIMENT_MODEL = "distilbert"
 sys.modules.setdefault("sentimental_cap_predictor.config", dummy_config)
 dummy_pkg.config = dummy_config
 
@@ -158,9 +159,7 @@ def test_read_cli_summarize_non_english(monkeypatch):
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    data = json.loads(result.stdout.strip())
-    assert data["text"] == "cuerpo"
-    assert data["summary"] == "translated"
+    assert result.stdout.strip() == "translated"
 
 
 def test_read_cli_translation_missing(monkeypatch):


### PR DESCRIPTION
## Summary
- refactor `news.fetch_gdelt` to use `GdeltClient`, `HtmlFetcher`, and `ArticleExtractor`
- make domain allow/block lists configurable via environment variables
- document domain policy env vars and adjust tests for new behavior

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_fetch_gdelt_store.py`
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_news_cli.py`
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_news_session.py`
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_chatbot_frontend.py`
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_gdelt_client.py tests/test_fetcher.py tests/test_extractor.py tests/test_article_reader.py` *(fails: JSONDecodeError and extractor assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68c38b7cc740832b90e0ca08356053b1