### PR TITLE
Add RSS feed connector with optional NewsAPI support

### DIFF
--- a/src/sentimental_cap_predictor/llm_core/connectors/__init__.py
+++ b/src/sentimental_cap_predictor/llm_core/connectors/__init__.py
@@ -7,4 +7,5 @@ __all__ = [
     "edgar_connector",
     "pubmed_connector",
     "github_connector",
+    "rss_connector",
 ]

--- a/src/sentimental_cap_predictor/llm_core/connectors/rss_connector.py
+++ b/src/sentimental_cap_predictor/llm_core/connectors/rss_connector.py
@@ -1,0 +1,115 @@
+"""Connector for ingesting articles from RSS feeds and optional NewsAPI."""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Dict, List
+
+import requests
+from loguru import logger
+
+NEWSAPI_URL = "https://newsapi.org/v2/top-headlines"
+
+
+def _parse_feed(xml_text: str) -> List[Dict[str, str]]:
+    """Parse a simple RSS/Atom feed into a list of dictionaries."""
+    root = ET.fromstring(xml_text)
+    entries: List[Dict[str, str]] = []
+    for item in root.findall(".//item"):
+        entries.append(
+            {
+                "title": item.findtext("title", default="").strip(),
+                "link": item.findtext("link", default="").strip(),
+                "summary": item.findtext("description", default="").strip(),
+                "published": item.findtext("pubDate", default="").strip(),
+            }
+        )
+    # Atom feeds use ``entry`` elements instead of ``item``
+    for entry in root.findall(".//{http://www.w3.org/2005/Atom}entry"):
+        link = ""
+        link_elem = entry.find("{http://www.w3.org/2005/Atom}link")
+        if link_elem is not None:
+            link = link_elem.get("href", "")
+        entries.append(
+            {
+                "title": entry.findtext("{http://www.w3.org/2005/Atom}title", default="").strip(),
+                "link": link,
+                "summary": entry.findtext("{http://www.w3.org/2005/Atom}summary", default="").strip(),
+                "published": entry.findtext("{http://www.w3.org/2005/Atom}updated", default="").strip(),
+            }
+        )
+    return entries
+
+
+def fetch_feeds(feed_urls: List[str]) -> List[Dict[str, str]]:
+    """Fetch and parse multiple RSS feeds.
+
+    Parameters
+    ----------
+    feed_urls:
+        List of RSS feed URLs to download and parse.
+    """
+
+    articles: List[Dict[str, str]] = []
+    for url in feed_urls:
+        try:
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            articles.extend(_parse_feed(response.text))
+        except Exception as exc:  # pragma: no cover - logging only
+            logger.warning("Failed to fetch %s: %s", url, exc)
+    return articles
+
+
+def load_feed_list(path: Path) -> List[str]:
+    """Load feed URLs from a text file (one per line)."""
+    return [line.strip() for line in path.read_text().splitlines() if line.strip() and not line.startswith("#")]
+
+
+def fetch_newsapi(api_key: str, query: str = "") -> List[Dict[str, str]]:
+    """Fetch articles using the NewsAPI.org service."""
+    params = {"apiKey": api_key}
+    if query:
+        params["q"] = query
+    response = requests.get(NEWSAPI_URL, params=params, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    articles: List[Dict[str, str]] = []
+    for article in data.get("articles", []):
+        articles.append(
+            {
+                "title": article.get("title", ""),
+                "link": article.get("url", ""),
+                "summary": article.get("description", ""),
+                "published": article.get("publishedAt", ""),
+            }
+        )
+    return articles
+
+
+def fetch_all(feed_urls: List[str], query: str = "") -> List[Dict[str, str]]:
+    """Fetch articles from RSS feeds and NewsAPI if a key is available."""
+    articles = fetch_feeds(feed_urls)
+    api_key = os.getenv("NEWSAPI_API_KEY")
+    if api_key:
+        try:
+            articles.extend(fetch_newsapi(api_key, query=query))
+        except Exception as exc:  # pragma: no cover - logging only
+            logger.warning("NewsAPI fetch failed: %s", exc)
+    return articles
+
+
+def fetch_from_file(path: Path, query: str = "") -> List[Dict[str, str]]:
+    """Convenience wrapper to fetch feeds listed in *path*."""
+    return fetch_all(load_feed_list(path), query=query)
+
+
+__all__ = [
+    "fetch_feeds",
+    "fetch_newsapi",
+    "fetch_all",
+    "fetch_from_file",
+    "load_feed_list",
+]

--- a/tests/test_rss_connector.py
+++ b/tests/test_rss_connector.py
@@ -1,0 +1,99 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import requests
+
+dummy_pkg = types.ModuleType("sentimental_cap_predictor")
+dummy_pkg.__path__ = []  # type: ignore[attr-defined]
+dummy_llm_pkg = types.ModuleType("sentimental_cap_predictor.llm_core")
+dummy_llm_pkg.__path__ = []  # type: ignore[attr-defined]
+sys.modules.setdefault("sentimental_cap_predictor", dummy_pkg)
+sys.modules.setdefault("sentimental_cap_predictor.llm_core", dummy_llm_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "sentimental_cap_predictor.llm_core.connectors.rss_connector",
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "sentimental_cap_predictor"
+    / "llm_core"
+    / "connectors"
+    / "rss_connector.py",
+)
+rss_connector = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = rss_connector
+spec.loader.exec_module(rss_connector)
+
+
+RSS_TEXT = """<?xml version='1.0'?>
+<rss version='2.0'>
+<channel>
+<title>Sample</title>
+<item>
+<title>First</title>
+<link>http://example.com/1</link>
+<description>Hello</description>
+<pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+</item>
+</channel>
+</rss>"""
+
+
+def test_load_feed_list(tmp_path: Path) -> None:
+    path = tmp_path / "feeds.txt"
+    path.write_text("http://example.com/rss\n#comment\nhttp://example.com/2\n")
+    urls = rss_connector.load_feed_list(path)
+    assert urls == ["http://example.com/rss", "http://example.com/2"]
+
+
+def test_fetch_feeds(monkeypatch):
+    class DummyResponse:
+        def __init__(self, text: str):
+            self.text = text
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, timeout):  # noqa: ANN001
+        return DummyResponse(RSS_TEXT)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    articles = rss_connector.fetch_feeds(["http://example.com/rss"])
+    assert len(articles) == 1
+    assert articles[0]["title"] == "First"
+
+
+def test_fetch_all_with_newsapi(monkeypatch):
+    class DummyResponse:
+        def __init__(self, text: str | None = None, payload: dict | None = None):
+            self.text = text
+            self._payload = payload
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._payload
+
+    def fake_get(url, params=None, timeout=30):  # noqa: ANN001
+        if url == "http://example.com/rss":
+            return DummyResponse(text=RSS_TEXT)
+        assert params["apiKey"] == "KEY"
+        return DummyResponse(payload={
+            "articles": [
+                {
+                    "title": "NewsAPI",
+                    "url": "http://newsapi.org/1",
+                    "description": "Desc",
+                    "publishedAt": "2024-01-01T00:00:00Z",
+                }
+            ]
+        })
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setenv("NEWSAPI_API_KEY", "KEY")
+    articles = rss_connector.fetch_all(["http://example.com/rss"], query="test")
+    titles = {a["title"] for a in articles}
+    assert "NewsAPI" in titles
+    monkeypatch.delenv("NEWSAPI_API_KEY")


### PR DESCRIPTION
## Summary
- Add `rss_connector` for ingesting RSS/Atom feeds from a configurable list
- Support optional NewsAPI integration gated by `NEWSAPI_API_KEY`
- Include tests for feed loading, RSS parsing, and NewsAPI usage

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_rss_connector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4274eb3ac832b8f74ea189f90f697