### PR TITLE
Add article summarization and scoring

### DIFF
--- a/src/sentimental_cap_predictor/news/store.py
+++ b/src/sentimental_cap_predictor/news/store.py
@@ -47,7 +47,9 @@ def _connect() -> sqlite3.Connection:
         CREATE TABLE IF NOT EXISTS contents (
             url TEXT PRIMARY KEY REFERENCES articles(url),
             text TEXT,
-            summary TEXT
+            summary TEXT,
+            sentiment REAL,
+            relevance REAL
         )
         """
     )
@@ -91,20 +93,29 @@ def upsert_article(data: Dict[str, Any]) -> None:
         )
 
 
-def upsert_content(url: str, text: str, summary: str | None = None) -> None:
+def upsert_content(
+    url: str,
+    text: str,
+    summary: str | None = None,
+    sentiment: float | None = None,
+    relevance: float | None = None,
+) -> None:
     """Insert or update article content for ``url``."""
+
     if not url:
         return
     with _connect() as conn:
         conn.execute(
             """
-            INSERT INTO contents (url, text, summary)
-            VALUES (?, ?, ?)
+            INSERT INTO contents (url, text, summary, sentiment, relevance)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(url) DO UPDATE SET
                 text=excluded.text,
-                summary=excluded.summary
+                summary=excluded.summary,
+                sentiment=excluded.sentiment,
+                relevance=excluded.relevance
             """,
-            (url, text, summary or ""),
+            (url, text, summary or "", sentiment, relevance),
         )
 
 

--- a/tests/test_news_session.py
+++ b/tests/test_news_session.py
@@ -41,6 +41,8 @@ fetch_gdelt_mod = SimpleNamespace(
     fetch_html=lambda url: "",
     extract_main_text=lambda html, url=None: "",
     summarize=lambda text: "",
+    score_sentiment=lambda text: 0.0,
+    score_relevance=lambda text, query: 0.0,
     domain_ok=lambda url: True,
     domain_blocked=lambda url: False,
     _store_chunks=lambda result: None,
@@ -83,6 +85,12 @@ def test_handle_fetch_sets_state_and_upserts(monkeypatch):
     def fake_summarize(text):  # noqa: ANN001
         return "Summary"
 
+    def fake_sentiment(text):  # noqa: ANN001
+        return 0.5
+
+    def fake_relevance(text, topic):  # noqa: ANN001
+        return 0.8
+
     def fake_upsert(doc_id, text, metadata):  # noqa: ANN001
         calls.append((doc_id, text, metadata))
 
@@ -98,6 +106,8 @@ def test_handle_fetch_sets_state_and_upserts(monkeypatch):
     monkeypatch.setattr(fg_mod, "fetch_html", fake_fetch_html)
     monkeypatch.setattr(fg_mod, "extract_main_text", fake_extract)
     monkeypatch.setattr(fg_mod, "summarize", fake_summarize)
+    monkeypatch.setattr(fg_mod, "score_sentiment", fake_sentiment)
+    monkeypatch.setattr(fg_mod, "score_relevance", fake_relevance)
     monkeypatch.setattr(fg_mod, "domain_ok", lambda url: True)
     monkeypatch.setattr(fg_mod, "domain_blocked", lambda url: False)
     monkeypatch.setattr(
@@ -114,6 +124,8 @@ def test_handle_fetch_sets_state_and_upserts(monkeypatch):
     )
     assert session.STATE.last_article["title"] == "Title topic1"
     assert calls  # upsert called
+    assert session.STATE.last_article["sentiment"] == 0.5
+    assert session.STATE.last_article["relevance"] == 0.8
 
     # Fetch another topic to ensure state replacement
     msg2 = session.handle_fetch("topic2")


### PR DESCRIPTION
## Summary
- Use lightweight transformers pipeline to summarize article text with fallback
- Compute sentiment and relevance scores for fetched news articles
- Persist sentiment and relevance in news content store and session state

## Testing
- `ruff check src tests` *(fails: `.config.RAW_DATA_DIR imported but unused` and other lint errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic', pandas, requests, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c4392cc79c832ba88a82095dc1e94a