### PR TITLE
Add weighted news scoring with EWMA smoothing

### DIFF
--- a/src/sentimental_cap_predictor/news/__init__.py
+++ b/src/sentimental_cap_predictor/news/__init__.py
@@ -1,9 +1,10 @@
 """Utilities for interacting with news APIs."""
 
-from .gdelt_client import ArticleStub, GdeltClient, search_gdelt
-from .fetcher import HtmlFetcher
-from .extractor import ArticleExtractor, ExtractedArticle
 from . import store
+from .extractor import ArticleExtractor, ExtractedArticle
+from .fetcher import HtmlFetcher
+from .gdelt_client import ArticleStub, GdeltClient, search_gdelt
+from .scoring import score_news
 
 __all__ = [
     "ArticleStub",
@@ -13,4 +14,5 @@ __all__ = [
     "ArticleExtractor",
     "ExtractedArticle",
     "store",
+    "score_news",
 ]

--- a/src/sentimental_cap_predictor/news/scoring.py
+++ b/src/sentimental_cap_predictor/news/scoring.py
@@ -1,0 +1,66 @@
+"""News article scoring utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def score_news(
+    df: pd.DataFrame,
+    *,
+    now: pd.Timestamp | None = None,
+    recency_weight: float = 0.5,
+    length_weight: float = 0.3,
+    credibility_weight: float = 0.2,
+    decay: float = 1.0,
+    ewma_span: int = 5,
+) -> pd.DataFrame:
+    """Compute weighted scores for news articles with EWMA smoothing.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing ``timestamp``, ``length`` and ``credibility``
+        columns.
+    now:
+        Reference time for the recency calculation. Defaults to the most recent
+        timestamp in ``df``.
+    recency_weight, length_weight, credibility_weight:
+        Weights applied to the recency, length and credibility components. They
+        do not need to sum to ``1`` but typically should.
+    decay:
+        Exponential decay factor for the recency component measured in days.
+    ewma_span:
+        Span parameter for exponential weighted moving average smoothing.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``df`` with added ``score`` and ``ewma_score`` columns.
+    """
+    if now is None:
+        now = pd.to_datetime(df["timestamp"]).max()
+
+    df = df.copy()
+
+    timestamp = pd.to_datetime(df["timestamp"])
+    age_days = (now - timestamp).dt.total_seconds() / 86400
+    recency = np.exp(-decay * age_days)
+
+    length_max = float(df["length"].max())
+    if length_max == 0:
+        length_max = 1.0
+    length_norm = df["length"] / length_max
+
+    score = (
+        recency_weight * recency
+        + length_weight * length_norm
+        + credibility_weight * df["credibility"]
+    )
+    df["score"] = score
+    df["ewma_score"] = score.ewm(span=ewma_span, adjust=False).mean()
+    return df
+
+
+__all__ = ["score_news"]

--- a/tests/test_news_scoring.py
+++ b/tests/test_news_scoring.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pandas as pd
+
+from sentimental_cap_predictor.news.scoring import score_news
+
+
+def test_score_news_applies_weights_and_ewma():
+    dates = ["2024-01-01", "2024-01-02", "2024-01-03"]
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(dates),
+            "length": [100, 50, 150],
+            "credibility": [0.9, 0.5, 0.1],
+        }
+    )
+
+    result = score_news(
+        df,
+        now=pd.Timestamp("2024-01-03"),
+        recency_weight=0.5,
+        length_weight=0.3,
+        credibility_weight=0.2,
+        decay=1.0,
+        ewma_span=2,
+    )
+
+    # Expected components
+    now = pd.Timestamp("2024-01-03")
+    age_days = (now - df["timestamp"]).dt.total_seconds() / 86400
+    recency = np.exp(-age_days)
+    length_norm = df["length"] / df["length"].max()
+    expected_score = 0.5 * recency
+    expected_score += 0.3 * length_norm
+    expected_score += 0.2 * df["credibility"]
+    expected_score = expected_score.rename("score")
+    ewm_series = expected_score.ewm(span=2, adjust=False).mean()
+    expected_ewma = ewm_series.rename("ewma_score")
+
+    pd.testing.assert_series_equal(
+        result["score"],
+        expected_score,
+        atol=1e-12,
+    )
+    pd.testing.assert_series_equal(
+        result["ewma_score"],
+        expected_ewma,
+        atol=1e-12,
+    )


### PR DESCRIPTION
## Summary
- add scoring module computing recency, length, and credibility weighted scores with EWMA smoothing
- expose scoring utility in news package
- test scoring to ensure weights and smoothing are applied

## Testing
- `pre-commit run --files src/sentimental_cap_predictor/news/scoring.py src/sentimental_cap_predictor/news/__init__.py tests/test_news_scoring.py`
- `pytest tests/test_news_scoring.py`

------
https://chatgpt.com/codex/tasks/task_e_68c43a358e74832b97a29e47d0fbdba7