### PR TITLE
Add optional Playwright-based fetcher

### DIFF
--- a/docs/chatbot_frontend.md
+++ b/docs/chatbot_frontend.md
@@ -103,6 +103,10 @@ response is the summary text; add `--json` to get a JSON object instead.
 
 Domain allow/block lists for GDELT results can be supplied through the
 `NEWS_ALLOWED_DOMAINS` and `NEWS_BLOCKED_DOMAINS` environment variables.
+To fetch pages that reject plain HTTP clients, enable a Playwright-powered
+fallback by setting `NEWS_USE_PLAYWRIGHT=1` and installing the `playwright`
+package along with its browsers. This adds overhead so it is disabled by
+default.
 
 ## Connector intents
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -115,6 +115,11 @@ object instead.
 GDELT domain filters can be configured via the `NEWS_ALLOWED_DOMAINS` and
 `NEWS_BLOCKED_DOMAINS` environment variables (comma-separated lists).
 
+Some sites reject standard HTTP clients. Set `NEWS_USE_PLAYWRIGHT=1` to enable a
+browser-based fallback fetcher powered by Playwright. This requires the
+`playwright` package and a browser install (`playwright install`) and may
+consume significant resources.
+
 ## GitHub Repository Data
 
 Utilities that pull information from the GitHub API can optionally use a

--- a/src/sentimental_cap_predictor/news/fetcher.py
+++ b/src/sentimental_cap_predictor/news/fetcher.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import random
 
 import httpx
 
 from .store import log_error
+
+try:  # pragma: no cover - optional dependency
+    from playwright.async_api import async_playwright
+except Exception:  # pragma: no cover - optional dependency
+    async_playwright = None
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +28,10 @@ class HtmlFetcher:
         max_concurrency: int = 8,
         use_env_proxy: bool = False,
     ) -> None:
-        limits = httpx.Limits(max_connections=20, max_keepalive_connections=20)
+        limits = httpx.Limits(
+            max_connections=20,
+            max_keepalive_connections=20,
+        )
         self.client = httpx.AsyncClient(
             timeout=timeout_s,
             headers={"User-Agent": "cap-predictor/1.0"},
@@ -34,31 +43,47 @@ class HtmlFetcher:
     async def get(self, url: str, *, max_retries: int = 3) -> str | None:
         """Return the body of ``url`` or ``None`` on failure.
 
-        Each request attempt is logged. Transient failures trigger exponential
-        back-off and are retried up to ``max_retries`` times. Final failures are
-        persisted to the ``errors`` table via :func:`log_error`.
+        Each request attempt is logged. Transient failures trigger
+        exponential back-off and are retried up to ``max_retries`` times.
+        Final failures are persisted to the ``errors`` table via
+        :func:`log_error`.
         """
 
         async with self._sem:
             delay = 0.5
+            resp: httpx.Response | None = None
             for attempt in range(1, max_retries + 1):
-                logger.info("GET %s (attempt %s/%s)", url, attempt, max_retries)
+                logger.info(
+                    "GET %s (attempt %s/%s)",
+                    url,
+                    attempt,
+                    max_retries,
+                )
                 try:
                     resp = await self.client.get(url, follow_redirects=True)
-                except (httpx.ProxyError, httpx.ConnectError, httpx.ReadTimeout) as exc:
+                except (
+                    httpx.ProxyError,
+                    httpx.ConnectError,
+                    httpx.ReadTimeout,
+                ) as exc:
                     logger.warning("Request error for %s: %s", url, exc)
                     resp = None
                 if resp and resp.status_code == 200 and resp.text:
                     return resp.text
                 reason = (
-                    f"status {resp.status_code}" if resp is not None else "network error"
+                    f"status {resp.status_code}"
+                    if resp is not None
+                    else "network error"
                 )
                 if attempt < max_retries and (
                     resp is None or resp.status_code in (403, 429)
                 ):
                     sleep_for = delay + random.random()
                     logger.info(
-                        "Retrying %s in %.2fs due to %s", url, sleep_for, reason
+                        "Retrying %s in %.2fs due to %s",
+                        url,
+                        sleep_for,
+                        reason,
                     )
                     await asyncio.sleep(sleep_for)
                     delay *= 2
@@ -66,12 +91,53 @@ class HtmlFetcher:
                 if resp is not None and resp.status_code not in (403, 429):
                     logger.warning("Giving up on %s due to %s", url, reason)
                     break
-            logger.error("Failed to fetch %s after %s attempts", url, max_retries)
+
+            use_browser = os.getenv("NEWS_USE_PLAYWRIGHT", "0") == "1"
+            blocked = resp is None or resp.status_code in (403, 429)
+            if use_browser and blocked:
+                if async_playwright is None:
+                    msg = "Playwright not installed; skipping browser fetch for %s"  # noqa: E501
+                    logger.warning(msg, url)
+                else:
+                    try:
+                        logger.info("Using Playwright to fetch %s", url)
+                        timeout = getattr(self.client.timeout, "read", 10.0)
+                        html = await _fetch_with_playwright(url, timeout)
+                        if html:
+                            return html
+                    except Exception as exc:  # pragma: no cover
+                        logger.warning(
+                            "Playwright fetch failed for %s: %s",
+                            url,
+                            exc,
+                        )
+
+            logger.error(
+                "Failed to fetch %s after %s attempts",
+                url,
+                max_retries,
+            )
             log_error(url, "fetch", reason)
             return None
 
     async def aclose(self) -> None:
         await self.client.aclose()
+
+
+async def _fetch_with_playwright(url: str, timeout_s: float) -> str | None:
+    """Return ``url`` content via Playwright or ``None`` on failure."""
+
+    if async_playwright is None:  # pragma: no cover - sanity check
+        return None
+    timeout_ms = int(timeout_s * 1000)
+    async with async_playwright() as pw:  # pragma: no cover - network/browser
+        browser = await pw.firefox.launch()
+        page = await browser.new_page()
+        try:
+            await page.goto(url, timeout=timeout_ms)
+            return await page.content()
+        finally:
+            await browser.close()
 
 
 __all__ = ["HtmlFetcher"]


### PR DESCRIPTION
## Summary
- allow HtmlFetcher to fall back to Playwright when `NEWS_USE_PLAYWRIGHT=1`
- document Playwright fallback for news utilities and chatbot
- test Playwright fallback behaviour

## Testing
- `python -m pre_commit run --files src/sentimental_cap_predictor/news/fetcher.py tests/test_fetcher.py docs/cli.md docs/chatbot_frontend.md`
- `pytest tests/test_fetcher.py tests/test_fetch_gdelt_store.py tests/test_news_cli.py tests/test_news_session.py` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c4474ca62c832b8e9c06878780b765